### PR TITLE
Update tomcat version to 9.0.65

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.11.3 -t geoserver:2.11.3 .
-ARG TOMCAT_VERSION=9.0.64
+ARG TOMCAT_VERSION=9.0.65
 ARG GS_VERSION=2.21.1
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/


### PR DESCRIPTION
This updates to the latest tomcat9 version, as 9.0.64 has been removed.