### PR TITLE
Troubleshoot Dockerfile handling of data directory and extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 
 # The GS_VERSION argument could be used like this to overwrite the default:
-# docker build --build-arg GS_VERSION=2.11.3 -t geoserver:2.11.3 .
+# docker build --build-arg GS_VERSION=2.21.2 -t geoserver:2.21.2 .
 ARG TOMCAT_VERSION=9.0.65
 ARG GS_VERSION=2.21.1
 ARG GS_DATA_PATH=./geoserver_data/
@@ -11,12 +11,13 @@ ARG CORS_ENABLED=false
 ARG CORS_ALLOWED_ORIGINS=*
 ARG CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
 ARG CORS_ALLOWED_HEADERS=*
-ARG STABLE_PLUGIN_URL=https://sourceforge.net/projects/geoserver/files/GeoServer/${GS_VERSION}/extensions
+ARG STABLE_PLUGIN_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/extensions
 
 # Environment variables
 ENV CATALINA_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 ENV GEOSERVER_VERSION=$GS_VERSION
 ENV GEOSERVER_DATA_DIR=/opt/geoserver_data/
+ENV GEOSERVER_REQUIRE_FILE=$GEOSERVER_DATA_DIR/global.xml
 ENV GEOSERVER_LIB_DIR=$CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
 ENV EXTRA_JAVA_OPTS="-Xms256m -Xmx1g"
 ENV CORS_ENABLED=$CORS_ENABLED
@@ -30,7 +31,7 @@ ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
 ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
 ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
 
-# see http://docs.geoserver.org/stable/en/user/production/container.html
+# see https://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
     -Djava.awt.headless=true -server \
     -Dfile.encoding=UTF-8 \
@@ -38,7 +39,6 @@ ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
     -Djavax.servlet.response.encoding=UTF-8 \
     -D-XX:SoftRefLRUPolicyMSPerMB=36000 \
     -Xbootclasspath/a:$CATALINA_HOME/lib/marlin.jar \
-    -Xbootclasspath/a:$CATALINA_HOME/lib/marlin-sun-java2d.jar \
     -Dsun.java2d.renderer=org.marlin.pisces.PiscesRenderingEngine \
     -Dorg.geotools.coverage.jaiext.enabled=true"
 
@@ -62,11 +62,12 @@ RUN wget -q https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apac
 WORKDIR /tmp
 
 # install geoserver
-RUN wget -q -O /tmp/geoserver.zip http://downloads.sourceforge.net/project/geoserver/GeoServer/$GEOSERVER_VERSION/geoserver-$GEOSERVER_VERSION-war.zip && \
+RUN wget -q -O /tmp/geoserver.zip https://downloads.sourceforge.net/project/geoserver/GeoServer/$GEOSERVER_VERSION/geoserver-$GEOSERVER_VERSION-war.zip && \
     unzip geoserver.zip geoserver.war -d $CATALINA_HOME/webapps && \
     mkdir -p $CATALINA_HOME/webapps/geoserver && \
     unzip -q $CATALINA_HOME/webapps/geoserver.war -d $CATALINA_HOME/webapps/geoserver && \
     rm $CATALINA_HOME/webapps/geoserver.war && \
+    mv $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/marlin-0.9.3.jar $CATALINA_HOME/lib/marlin.jar && \
     mkdir -p $GEOSERVER_DATA_DIR
 
 COPY $GS_DATA_PATH $GEOSERVER_DATA_DIR

--- a/README.md
+++ b/README.md
@@ -8,24 +8,107 @@ This Dockerfile can be used to create images for all geoserver versions since 2.
 * GeoServer
   * Support of custom fonts (e.g. for SLD styling)
   * CORS support
+  * Support extensions
+  * Support additional libraries
 
-**IMPORTANT NOTE:** Please change the default geoserver master password! The default masterpw is located in this file (within the docker container): `/opt/geoserver_data/security/masterpw/default/masterpw`
+## How to Use
 
-## How to build?
+### How to run official release?
 
-`docker build -t {YOUR_TAG} .`
+Pull an official image use ``docker.osgeo.org/{{VERSION}}``:
 
-## How to quickstart?
+```
+docker pull docker.osgeo.org/geoserver:2.21.1
+docker run -it -p 80:8080 docker.osgeo.org/geoserver:2.21.1
+```
 
-Build the image as described above, then:
+Check http://localhost/geoserver to see the geoserver page,
+and login with geoserver default `admin:geoserver` credentials.
 
-`docker run -it -p 80:8080 {YOUR_TAG}`
+**IMPORTANT NOTE:** Please change the default ``geoserver`` and ``master`` passwords.
+
+For more information see the user-guide [docker installation instructions](https://docs.geoserver.org/latest/en/user/installation/docker).
+
+
+### How to run local build?
+
+After building run using local tag:
+
+```
+docker run -it -p 80:8080 {YOUR_TAG}
+```
 
 or if you want to start the container daemonized:
 
-`docker run -d -p 80:8080 {YOUR_TAG}`
+```
+docker run -d -p 80:8080 {YOUR_TAG}
+```
 
-Check http://localhost/geoserver to see the geoserver page and login with geoserver defaults `admin:geoserver`
+## How to download and install additional extensions on startup?
+
+The ``startup.sh`` script allows some customization on startup:
+
+* ``INSTALL_EXTENSIONS`` to ``true`` to download and install extensions
+* ``STABLE_EXTENSIONS`` list of extensions to download and install
+* ``CORS_ENABLED`` 
+
+Example installing wps and ysld extensions:
+
+```
+docker run -it -p 80:8080 \
+  --env INSTALL_EXTENSIONS=true --env STABLE_EXTENSIONS="wps,ysld" \
+  docker.osgeo.org/geoserver:2.21.1 
+```
+
+### How to install additional extensions from local folder?
+
+If you want to add geoserver extensions/libs by using a mount, you can add something like
+
+```
+docker run -it -p 80:8080 \
+  --mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind \
+  docker.osgeo.org/geoserver:2.21.1 
+```
+
+### How to add additional fonts to the docker image (e.g. for SLD styling)?
+
+If you want to add custom fonts (the base image only contains 26 fonts) by using a mount:
+
+```
+docker run -it -p 80:8080 \
+  --mount src="/dir/with/fonts/on/host",target=/opt/additional_fonts,type=bind \
+  docker.osgeo.org/geoserver:2.21.1
+```
+
+**Note:** Do not change the target value!
+
+## Troubleshooting
+
+### How to watch geoserver.log from host?
+
+To watch ``geoserver.log`` of a running container:`
+
+```
+docker exec -it {CONTAINER_ID} tail -f /opt/geoserver_data/logs/geoserver.log
+```
+
+### How to use the docker-compose demo?
+
+The ``docker-compose-demo.yml`` to build with your own data directory and extensions.
+
+Stage geoserver data directory contents into ``geoserver_data``, and any extensions into ``additional_libs`` folder.
+
+Run ``docker-compose``:
+
+```
+docker-compose -f docker-compose-demo.yml up --build
+```
+
+
+
+## How to Build?
+
+`docker build -t {YOUR_TAG} .`
 
 ## How to build a specific GeoServer version?
 
@@ -50,31 +133,3 @@ Put your `*.jar` files (e.g. the WPS extension) in the `additional_libs` folder 
 **Note:** Similar to the GeoServer data path from above, you can also configure the path to the additional libraries by passing the `ADDITIONAL_LIBS_PATH` argument when building:
 
 `--build-arg ADDITIONAL_LIBS_PATH={RELATIVE_PATH_TO_YOUR_LIBS}`
-
-## How to add additional libs using an existing docker image?
-
-If you want to add geoserver extensions/libs by using a mount, you can add something like
-
-```
---mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind
-```
-
-## How to add additional fonts to the docker image (e.g. for SLD styling)?
-
-If you want to add custom fonts (the base image only contains 26 fonts) by using a mount, you can add something like
-
-```
---mount src="/dir/with/fonts/on/host",target=/opt/additional_fonts,type=bind
-```
-
-to your `docker run` command.
-
-**Note:** Do not change the target value!
-
-## How to watch geoserver.log from host?
-
-`docker exec -it {CONTAINER_ID} tail -f /opt/geoserver_data/logs/geoserver.log`
-
-## How to use the docker-compose demo?
-
-`docker-compose -f docker-compose-demo.yml up --build`

--- a/additional_fonts/.gitignore
+++ b/additional_fonts/.gitignore
@@ -1,5 +1,6 @@
 # Ignore everything in this directory
 *
+*/
 # Except this file
 !.gitignore
 

--- a/additional_libs/.gitignore
+++ b/additional_libs/.gitignore
@@ -1,5 +1,6 @@
 # Ignore everything in this directory
 *
+*/
 # Except this file
 !.gitignore
 

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -4,18 +4,15 @@ services:
     build:
       context: .
       args:
-        - GEOSERVER_VERSION=2.21.0
+        - GEOSERVER_VERSION=2.21.1
         - CORS_ENABLED=true
         - CORS_ALLOWED_METHODS=GET,POST,PUT,HEAD,OPTIONS
     ports:
-      - 8080:8080
+      - 80:8080
     environment:
       - INSTALL_EXTENSIONS=true
       - STABLE_EXTENSIONS=wps,csw
-      - INITIAL_MEMORY=1G
-      - MAXIMUM_MEMORY=2G
-      - JAIEXT_ENABLED=true
-      - GEOSERVER_DATA_DIR=/opt/geoserver_data/
+      - EXTRA_JAVA_OPTS=-Xms1G -Xmx2G
     volumes:
-      - ./demo_data/geoserver_data:/opt/geoserver_data/:Z
-      - ./demo_data/additional_libs:/opt/additional_libs:Z # by mounting this we can install libs from host on startup
+      - ./geoserver_data:/opt/geoserver_data/:Z
+      - ./additional_libs:/opt/additional_libs:Z # by mounting this we can install libs from host on startup

--- a/geoserver_data/.gitignore
+++ b/geoserver_data/.gitignore
@@ -1,5 +1,6 @@
 # Ignore everything in this directory
 *
+*/
 # Except this file
 !.gitignore
 

--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -10,7 +10,7 @@ function download_extension() {
       echo "$DOWNLOAD_FILE already exists. Skipping download."
   else
     if curl --output /dev/null --silent --head --fail "${URL}"; then
-        echo -e "\nDownloading ${EXTENSION}-extension from ${URL} to ${DOWNLOAD_FILE}"
+        echo -e "\nDownloading ${EXTENSION} extension from ${URL} to ${DOWNLOAD_FILE}"
         wget --progress=bar:force:noscroll -c --no-check-certificate "${URL}" -O ${DOWNLOAD_FILE}
       else
         echo "URL does not exist: ${URL}"
@@ -21,6 +21,9 @@ function download_extension() {
 # Download stable plugins only if INSTALL_EXTENSIONS is true
 if [ "$INSTALL_EXTENSIONS" = "true" ]; then
   echo "Starting download of extensions"
+  if [ ! -d "$ADDITIONAL_LIBS_DIR" ]; then
+    mkdir -p $ADDITIONAL_LIBS_DIR
+  fi
   for EXTENSION in $(echo "${STABLE_EXTENSIONS}" | tr ',' ' '); do
     URL="${STABLE_PLUGIN_URL}/geoserver-${GEOSERVER_VERSION}-${EXTENSION}-plugin.zip"
     download_extension ${URL} ${EXTENSION}

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
+echo "Welcome to GeoServer $GEOSERVER_VERSION"
+
+## install release data directory if needed before starting tomcat
+if [ ! -f "$GEOSERVER_REQUIRE_FILE" ]; then
+    echo "Initialize $GEOSERVER_DATA_DIR from data directory included in geoserver.war"
+    cp -r $CATALINA_HOME/webapps/geoserver/data/* $GEOSERVER_DATA_DIR
+fi
 
 ## install GeoServer extensions before starting the tomcat
 /opt/install-extensions.sh
@@ -11,7 +18,7 @@ if [ -d "$ADDITIONAL_LIBS_DIR" ] && [ $count != 0 ]; then
 fi
 
 # copy additional fonts before starting the tomcat
-# we also count whether at least one file with the extensions exists
+# we also count whether at least one file with the fonts exists
 count=`ls -1 *.ttf 2>/dev/null | wc -l`
 if [ -d "$ADDITIONAL_FONTS_DIR" ] && [ $count != 0 ]; then
     cp $ADDITIONAL_FONTS_DIR/*.ttf /usr/share/fonts/truetype/
@@ -23,6 +30,7 @@ fi
 # (this will only happen if our filter has not yet been added before)
 if [ "${CORS_ENABLED}" = "true" ]; then
   if ! grep -q DockerGeoServerCorsFilter "$CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml"; then
+    echo "Enable CORS for $CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml"
     sed -i "\:</web-app>:i\\
     <filter>\n\
       <filter-name>DockerGeoServerCorsFilter</filter-name>\n\


### PR DESCRIPTION
In writing docs and updating readme I found a few things to fix:

* [x] installing extensions on startup now works (had incorrect download location)
* [x] global.xml required file check, install release data directory if needed (since it is already downloaded)
* [x] docker-compose-demo referencing environmental variables no longer used
* [x] some readme instructions out of date or untested

