### PR TITLE
Skip demo data on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ ENV STABLE_EXTENSIONS=''
 ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
 ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
 ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
+ENV SKIP_DEMO_DATA=false
 
 # see https://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To pull an official image use ``docker.osgeo.org/geoserver:{{VERSION}}``, e.g.:
 docker pull docker.osgeo.org/geoserver:2.21.1
 ```
 
-Afterwards you can run the pulled image locally with: 
+Afterwards you can run the pulled image locally with:
 
 ```
 docker run -it -p 80:8080 docker.osgeo.org/geoserver:2.21.1
@@ -48,11 +48,16 @@ To use an external folder as your geoserver data directory.
 ```
 docker run -it -p 80:8080 \
   --mount src="/absolute/path/on/host",target=/opt/geoserver_data/,type=bind \
-  docker.osgeo.org/geoserver:2.21.1 
+  docker.osgeo.org/geoserver:2.21.1
 ```
 
 An empty data directory will be populated on first use. You can easily update GeoServer while
 using the same data directory.
+
+### How to start a GeoServer without sample data?
+
+This image populates GeoServer with demo data by default. For production scenarios this is typically not desired.
+Setting the environment varibale `SKIP_DEMO_DATA` can be set to `true` to create an empty GeoServer.
 
 ### How to download and install additional extensions on startup?
 
@@ -60,14 +65,14 @@ The ``startup.sh`` script allows some customization on startup:
 
 * ``INSTALL_EXTENSIONS`` to ``true`` to download and install extensions
 * ``STABLE_EXTENSIONS`` list of extensions to download and install
-* ``CORS_ENABLED`` 
+* ``CORS_ENABLED``
 
 Example installing wps and ysld extensions:
 
 ```
 docker run -it -p 80:8080 \
   --env INSTALL_EXTENSIONS=true --env STABLE_EXTENSIONS="wps,ysld" \
-  docker.osgeo.org/geoserver:2.21.1 
+  docker.osgeo.org/geoserver:2.21.1
 ```
 
 The list of extensions (taken from SourceForge download page):
@@ -92,7 +97,7 @@ If you want to add geoserver extensions/libs by using a mount, you can add somet
 ```
 docker run -it -p 80:8080 \
   --mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind \
-  docker.osgeo.org/geoserver:2.21.1 
+  docker.osgeo.org/geoserver:2.21.1
 ```
 
 ### How to add additional fonts to the docker image (e.g. for SLD styling)?
@@ -187,7 +192,7 @@ docker build \
   -t {YOUR_TAG} .
 ```
 
-## How to release? 
+## How to release?
 
 ### How to publish official release?
 
@@ -200,7 +205,7 @@ docker build -t geoserver-docker.osgeo.org/geoserver:2.21.1 .
 
 Login using with osgeo user id:
 ```
-docker login geoserver-docker.osgeo.org 
+docker login geoserver-docker.osgeo.org
 ```
 
 Push to osgeo repository:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ using the same data directory.
 ### How to start a GeoServer without sample data?
 
 This image populates GeoServer with demo data by default. For production scenarios this is typically not desired.
-Setting the environment varibale `SKIP_DEMO_DATA` can be set to `true` to create an empty GeoServer.
+Setting the environment variable `SKIP_DEMO_DATA` can be set to `true` to create an empty GeoServer.
 
 ### How to download and install additional extensions on startup?
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ using the same data directory.
 ### How to start a GeoServer without sample data?
 
 This image populates GeoServer with demo data by default. For production scenarios this is typically not desired.
-Setting the environment variable `SKIP_DEMO_DATA` can be set to `true` to create an empty GeoServer.
+The environment variable `SKIP_DEMO_DATA` can be set to `true` to create an empty GeoServer.
 
 ### How to download and install additional extensions on startup?
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 echo "Welcome to GeoServer $GEOSERVER_VERSION"
 
+## Skip demo data
+if [ "${SKIP_DEMO_DATA}" = "true" ]; then
+  unset GEOSERVER_REQUIRE_FILE
+fi
+
 ## install release data directory if needed before starting tomcat
-if [ ! -f "$GEOSERVER_REQUIRE_FILE" ]; then
-    echo "Initialize $GEOSERVER_DATA_DIR from data directory included in geoserver.war"
-    cp -r $CATALINA_HOME/webapps/geoserver/data/* $GEOSERVER_DATA_DIR
+if [ ! -z "$GEOSERVER_REQUIRE_FILE" ] && [ ! -f "$GEOSERVER_REQUIRE_FILE" ]; then
+  echo "Initialize $GEOSERVER_DATA_DIR from data directory included in geoserver.war"
+  cp -r $CATALINA_HOME/webapps/geoserver/data/* $GEOSERVER_DATA_DIR
 fi
 
 ## install GeoServer extensions before starting the tomcat


### PR DESCRIPTION
- This PR makes it possible to create an empty GeoServer without demo data, it can be controlled via `SKIP_DEMO_DATA=true`
- The motivation is have a clean GeoServer in production scenarios
- the current behavior of the image stays the same i.e. a new created GeoServer will be populated with demo data
- The change of the PR tries to build around the current usage of the environment variable [`GEOSERVER_REQUIRE_FILE`](https://docs.geoserver.org/stable/en/user/datadirectory/setting.html#require-files-to-exist). This variable is also checked by GeoServer itself and is used to check if demo data should be created. 

Test setup: 
```shell
# build image
docker build -t gs-dev . 

# creates a "clean" GeoServer without demo data
docker run \
  -p 8080:8080 \
  -e SKIP_DEMO_DATA=true \
  gs-dev
```