### PR TITLE
Feature/root webapp redirect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # The GS_VERSION argument could be used like this to overwrite the default:
 # docker build --build-arg GS_VERSION=2.21.2 -t geoserver:2.21.2 .
-ARG TOMCAT_VERSION=9.0.65
+ARG TOMCAT_VERSION=9.0.68
 ARG GS_VERSION=2.21.1
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN apt update && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/
-RUN wget -q https://dlcdn.apache.org/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
+RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
     tar xf apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
     rm apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
     rm -rf /opt/apache-tomcat-${TOMCAT_VERSION}/webapps/ROOT && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
 ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
 ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
 ENV SKIP_DEMO_DATA=false
+ENV ROOT_WEBAPP_REDIRECT=false
 
 # see https://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ using the same data directory.
 This image populates GeoServer with demo data by default. For production scenarios this is typically not desired.
 The environment variable `SKIP_DEMO_DATA` can be set to `true` to create an empty GeoServer.
 
+### How to issue a redirect from the root ("/") to GeoServer web interface ("/geoserver/web")?
+
+By default, the ROOT webapp is not available which makes requests to the root endpoint "/" return a 404 error.
+The environment variable `ROOT_WEBAPP_REDIRECT` can be set to `true` to issue a permanent redirect to the web interface.
+
 ### How to download and install additional extensions on startup?
 
 The ``startup.sh`` script allows some customization on startup:

--- a/startup.sh
+++ b/startup.sh
@@ -6,6 +6,22 @@ if [ "${SKIP_DEMO_DATA}" = "true" ]; then
   unset GEOSERVER_REQUIRE_FILE
 fi
 
+## Add a permanent redirect (HTTP 301) from the root webapp ("/") to geoserver web interface ("/geoserver/web")
+if [ "${ROOT_WEBAPP_REDIRECT}" = "true" ]; then
+  if [ ! -d $CATALINA_HOME/webapps/ROOT ]; then
+      mkdir $CATALINA_HOME/webapps/ROOT
+  fi
+
+  cat > $CATALINA_HOME/webapps/ROOT/index.jsp << EOF
+<%
+  final String redirectURL = "/geoserver/web/";
+  response.setStatus(HttpServletResponse.SC_MOVED_PERMANENTLY);
+  response.setHeader("Location", redirectURL);
+%>
+EOF
+fi
+
+
 ## install release data directory if needed before starting tomcat
 if [ ! -z "$GEOSERVER_REQUIRE_FILE" ] && [ ! -f "$GEOSERVER_REQUIRE_FILE" ]; then
   echo "Initialize $GEOSERVER_DATA_DIR from data directory included in geoserver.war"


### PR DESCRIPTION
## Objective
This PR allow the configuration of the ROOT webapp ("/") to issue an HTTP 301 redirect to the GeoServer web interface ("/geoserver/web"). The current behaviour is that the ROOT webapp is removed during the image build and request to the root  ("/") return an HTTP 404. 
Adds a new env variable `ROOT_WEBAPP_REDIRECT` to enable or not the redirect.


Also upgrades the tomcat version as 9.0.65 is no longer present in dlcdn.apache.org and gives 404 on image build.


## Test setup
By default, the ROOT_WEBAPP_REDIRECT=false
```bash
# Build image
docker build -t gs-dev . 
```

### Current hehaviour
```bash
# Run container
docker run --name gs-dev --rm -d \
  -p 8085:8080 \
  gs-dev


# Request
curl -v localhost:8085/
# 404 as expected
*   Trying 127.0.0.1:8085...
* Connected to localhost (127.0.0.1) port 8085 (#0)
> GET / HTTP/1.1
> Host: localhost:8085
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 404 
< Content-Type: text/html;charset=utf-8
< Content-Language: en
< Content-Length: 682
< Date: Sun, 16 Oct 2022 11:35:55 GMT
< 
* Connection #0 to host localhost left intact
<!doctype html><html lang="en"><head><title>HTTP Status 404 – Not Found</title><style type="text/css">body {font-family:Tahoma,Arial,sans-serif;} h1, h2, h3, b {color:white;background-color:#525D76;} h1 {font-size:22px;} h2 {font-size:16px;} h3 {font-size:14px;} p {font-size:12px;} a {color:black;} .line {height:1px;background-color:#525D76;border:none;}</style></head><body><h1>HTTP Status 404 – Not Found</h1><hr class="line" /><p><b>Type</b> Status Report</p><p><b>Description</b> The origin server did not find a current representation for the target resource or is not willing to disclose that one exists.</p><hr class="line" /><h3>Apache Tomcat/9.0.68</h3></body></html>
```

### New behaviour
```bash
# Recreate container
docker stop gs-dev

docker run --name gs-dev --rm -d \
  -p 8085:8080 \
  -e ROOT_WEBAPP_REDIRECT=true \
  gs-dev

# Request
curl -v localhost:8085/
*   Trying 127.0.0.1:8085...
* Connected to localhost (127.0.0.1) port 8085 (#0)
> GET / HTTP/1.1
> Host: localhost:8085
> User-Agent: curl/7.81.0
> Accept: */*
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 301 
< Set-Cookie: JSESSIONID=3ECEAFA107E9E4EC97BFF911FE134FCD; Path=/; HttpOnly
< Location: /geoserver/web/
< Content-Type: text/html;charset=ISO-8859-1
< Content-Length: 1
< Date: Sun, 16 Oct 2022 11:39:36 GMT
< 

* Connection #0 to host localhost left intact
```



