### PR TITLE
Making sure additional fonts are correctly counted

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -41,7 +41,7 @@ fi
 
 # copy additional fonts before starting the tomcat
 # we also count whether at least one file with the fonts exists
-count=`ls -1 *.ttf 2>/dev/null | wc -l`
+count=`ls -1 $ADDITIONAL_FONTS_DIR/*.ttf 2>/dev/null | wc -l`
 if [ -d "$ADDITIONAL_FONTS_DIR" ] && [ $count != 0 ]; then
     cp $ADDITIONAL_FONTS_DIR/*.ttf /usr/share/fonts/truetype/
     echo "Installed $count TTF font file(s) from the additional fonts folder"


### PR DESCRIPTION
Currently the additional fonts installation fails as they are wrongly counted in the startup.sh script.