### PR TITLE
Support for nightly builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -54,3 +54,67 @@ docker build \
   --build-arg ADDITIONAL_LIBS_PATH={RELATIVE_PATH_TO_YOUR_LIBS}
   -t {YOUR_TAG} .
 ```
+
+## How to build from nightly snapshot releases?
+
+By default ``WAR_ZIP_URL``, ``STABLE_PLUGIN_URL`` make use of sourceforge downloads to obtain official releases.
+
+Override these arguments to make use of build.geoserver.org nightly releases:
+
+* ``--build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/${GS_VERSION}/geoserver-${GS_VERSION}-latest-war.zip`` 
+* ``--build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/${GS_VERSION}/ext-latest/``
+* ``--build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/${GS_VERSION}/community-latest/``
+
+
+Here is a working example for building 2.23.x nightly build::
+```
+docker build \
+  --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/2.23.x/geoserver-2.23.x-latest-war.zip \
+  --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/2.23.x/ext-latest/ \
+  --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/2.23.x/community-latest/ \
+  --build-arg GS_VERSION=2.23-SNAPSHOT \
+  -t 2.23.x .
+```
+
+When running both stable extensions and community modules can be included:
+
+```
+docker run -it -p 80:8080 \
+  --env INSTALL_EXTENSIONS=true \
+  --env STABLE_EXTENSIONS="ysld" \
+  --env COMMUNITY_EXTENSIONS="ogcapi" \
+  -t 2.23.x
+```
+
+Community modules are only available for nightly builds as they have not yet met the requirements for production use. Developers have shared these to attract participation, feedback and funding.
+
+## How to build from main snapshot releases?
+
+The build.geoserver.org output for the ``main`` branch requires the following:
+
+* ``--build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip`` 
+* ``--build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/main/ext-latest/``
+* ``--build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest/``
+
+
+Here is a working example for building main branch as 2.24.x build:
+
+```
+docker build \
+  --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip \
+  --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/main/ext-latest/ \
+  --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest/ \
+  --build-arg GS_VERSION=2.24-SNAPSHOT \
+  -t 2.24.x .
+```
+
+When running both [stable extensions](https://build.geoserver.org/geoserver/main/ext-latest/) and [community modules](https://build.geoserver.org/geoserver/main/community-latest/) can be included:
+
+```
+docker run -it -p 80:8080 \
+  --env INSTALL_EXTENSIONS=true \
+  --env STABLE_EXTENSIONS="wps,css" \
+  --env COMMUNITY_EXTENSIONS="ogcapi-coverages,ogcapi-dggs,ogcapi-features,ogcapi-images,ogcapi-maps,ogcapi-styles,ogcapi-tiled-features,ogcapi-tiles" \
+  -t 2.24.x
+```
+

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,56 @@
+# Build Instructions
+
+## How to build a local image?
+
+```shell
+docker build -t {YOUR_TAG} .
+```
+
+## How to run local build?
+
+After building run using local tag:
+
+```shell
+docker run -it -p 80:8080 {YOUR_TAG}
+```
+
+## How to build a specific GeoServer version?
+
+```shell
+docker build \
+  --build-arg GS_VERSION={YOUR_VERSION} \
+  -t {YOUR_TAG} .
+```
+
+## How to build with custom geoserver data directory?
+
+```shell
+docker build \
+  --build-arg GS_DATA_PATH={RELATIVE_PATH_TO_YOUR_GS_DATA} \
+  -t {YOUR_TAG} .
+```
+
+**Note:** The passed path **must not** be absolute! Instead, the path should be within the build context (e.g. next to the Dockerfile) and should be passed as a relative path, e.g. `GS_DATA_PATH=./my_data/`
+
+## Can a build use a specific GeoServer version AND custom data?
+
+Yes! Just pass the `--build-arg` param twice, e.g.
+
+```shell
+docker build \
+  --build-arg GS_VERSION={VERSION} \
+  --build-arg GS_DATA_PATH={PATH} \
+  -t {YOUR_TAG} .
+```
+
+## How to build with additional libs/extensions/plugins?
+
+Put your `*.jar` files (e.g. the WPS extension) in the `additional_libs` folder and build with one of the commands from above! (They will be copied to the GeoServer `WEB-INF/lib` folder during the build.)
+
+**Note:** Similar to the GeoServer data path from above, you can also configure the path to the additional libraries by passing the `ADDITIONAL_LIBS_PATH` argument when building:
+
+```shell
+docker build \
+  --build-arg ADDITIONAL_LIBS_PATH={RELATIVE_PATH_TO_YOUR_LIBS}
+  -t {YOUR_TAG} .
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:22.04
 
 # The GS_VERSION argument could be used like this to overwrite the default:
-# docker build --build-arg GS_VERSION=2.21.2 -t geoserver:2.21.2 .
-ARG TOMCAT_VERSION=9.0.68
-ARG GS_VERSION=2.22.0
+# docker build --build-arg GS_VERSION=2.23.0 -t geoserver:2.23.0 .
+ARG TOMCAT_VERSION=9.0.74
+ARG GS_VERSION=2.23.0
 ARG GS_DATA_PATH=./geoserver_data/
 ARG ADDITIONAL_LIBS_PATH=./additional_libs/
 ARG ADDITIONAL_FONTS_PATH=./additional_fonts/
@@ -11,7 +11,9 @@ ARG CORS_ENABLED=false
 ARG CORS_ALLOWED_ORIGINS=*
 ARG CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
 ARG CORS_ALLOWED_HEADERS=*
+ARG WAR_ZIP_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
 ARG STABLE_PLUGIN_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/extensions
+ARG COMMUNITY_PLUGIN_URL=''
 
 # Environment variables
 ENV CATALINA_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
@@ -26,8 +28,11 @@ ENV CORS_ALLOWED_METHODS=$CORS_ALLOWED_METHODS
 ENV CORS_ALLOWED_HEADERS=$CORS_ALLOWED_HEADERS
 ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_EXTENSIONS=false
+ENV WAR_ZIP_URL=$WAR_ZIP_URL
 ENV STABLE_EXTENSIONS=''
 ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
+ENV COMMUNITY_EXTENSIONS=''
+ENV COMMUNITY_PLUGIN_URL=$COMMUNITY_PLUGIN_URL
 ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
 ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
 ENV SKIP_DEMO_DATA=false
@@ -63,7 +68,7 @@ RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/b
 WORKDIR /tmp
 
 # install geoserver
-RUN wget -q -O /tmp/geoserver.zip https://downloads.sourceforge.net/project/geoserver/GeoServer/$GEOSERVER_VERSION/geoserver-$GEOSERVER_VERSION-war.zip && \
+RUN wget -q -O /tmp/geoserver.zip $WAR_ZIP_URL && \
     unzip geoserver.zip geoserver.war -d $CATALINA_HOME/webapps && \
     mkdir -p $CATALINA_HOME/webapps/geoserver && \
     unzip -q $CATALINA_HOME/webapps/geoserver.war -d $CATALINA_HOME/webapps/geoserver && \

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This Dockerfile can be used to create images for all geoserver versions since 2.
   * Support extensions
   * Support additional libraries
 
-## How to Use
+This README.md file covers use of official docker image, additional [build](BULD.md) and [release](RELEASE.md) instructions are available.
 
-### How to run official release?
+## How to run official release?
 
 To pull an official image use ``docker.osgeo.org/geoserver:{{VERSION}}``, e.g.:
 
@@ -40,7 +40,7 @@ and login with geoserver default `admin:geoserver` credentials.
 
 For more information see the user-guide [docker installation instructions](https://docs.geoserver.org/latest/en/user/installation/docker.html).
 
-### How to mount an external folder for use as a data directory
+## How to mount an external folder for use as a data directory
 
 To use an external folder as your geoserver data directory.
 
@@ -53,7 +53,7 @@ docker run -it -p 80:8080 \
 An empty data directory will be populated on first use. You can easily update GeoServer while
 using the same data directory.
 
-### How to start a GeoServer without sample data?
+## How to start a GeoServer without sample data?
 
 This image populates ``/opt/geoserver_data/`` with demo data by default. For production scenarios this is typically not desired.
 
@@ -65,12 +65,12 @@ docker run -it -p 80:8080 \
   docker.osgeo.org/geoserver:2.22.0
 ```
 
-### How to issue a redirect from the root ("/") to GeoServer web interface ("/geoserver/web")?
+## How to issue a redirect from the root ("/") to GeoServer web interface ("/geoserver/web")?
 
 By default, the ROOT webapp is not available which makes requests to the root endpoint "/" return a 404 error.
 The environment variable `ROOT_WEBAPP_REDIRECT` can be set to `true` to issue a permanent redirect to the web interface.
 
-### How to download and install additional extensions on startup?
+## How to download and install additional extensions on startup?
 
 The ``startup.sh`` script allows some customization on startup:
 
@@ -101,7 +101,7 @@ dxf          importer        netcdf        vectortiles      ysld
 excel        inspire         ogr-wfs       wcs2_0-eo
 ```
 
-### How to install additional extensions from local folder?
+## How to install additional extensions from local folder?
 
 If you want to add geoserver extensions/libs, place the respective jar files in a directory and mount it like
 
@@ -111,7 +111,7 @@ docker run -it -p 80:8080 \
   docker.osgeo.org/geoserver:2.22.0
 ```
 
-### How to add additional fonts to the docker image (e.g. for SLD styling)?
+## How to add additional fonts to the docker image (e.g. for SLD styling)?
 
 If you want to add custom fonts (the base image only contains 26 fonts) by using a mount:
 
@@ -123,17 +123,7 @@ docker run -it -p 80:8080 \
 
 **Note:** Do not change the target value!
 
-## Troubleshooting
-
-### How to watch geoserver.log from host?
-
-To watch ``geoserver.log`` of a running container:
-
-```shell
-docker exec -it {CONTAINER_ID} tail -f /opt/geoserver_data/logs/geoserver.log
-```
-
-### How to use the docker-compose demo?
+## How to use the docker-compose demo?
 
 The ``docker-compose-demo.yml`` to build with your own data directory and extensions.
 
@@ -145,99 +135,12 @@ Run ``docker-compose``:
 docker-compose -f docker-compose-demo.yml up --build
 ```
 
-## How to Build?
+## Troubleshooting
 
-### How to build a local image?
+### How to watch geoserver.log from host?
 
-```shell
-docker build -t {YOUR_TAG} .
-```
-
-### How to run local build?
-
-After building run using local tag:
+To watch ``geoserver.log`` of a running container:
 
 ```shell
-docker run -it -p 80:8080 {YOUR_TAG}
+docker exec -it {CONTAINER_ID} tail -f /opt/geoserver_data/logs/geoserver.log
 ```
-
-### How to build a specific GeoServer version?
-
-```shell
-docker build \
-  --build-arg GS_VERSION={YOUR_VERSION} \
-  -t {YOUR_TAG} .
-```
-
-### How to build with custom geoserver data directory?
-
-```shell
-docker build \
-  --build-arg GS_DATA_PATH={RELATIVE_PATH_TO_YOUR_GS_DATA} \
-  -t {YOUR_TAG} .
-```
-
-**Note:** The passed path **must not** be absolute! Instead, the path should be within the build context (e.g. next to the Dockerfile) and should be passed as a relative path, e.g. `GS_DATA_PATH=./my_data/`
-
-### Can a build use a specific GeoServer version AND custom data?
-
-Yes! Just pass the `--build-arg` param twice, e.g.
-
-```shell
-docker build \
-  --build-arg GS_VERSION={VERSION} \
-  --build-arg GS_DATA_PATH={PATH} \
-  -t {YOUR_TAG} .
-```
-
-### How to build with additional libs/extensions/plugins?
-
-Put your `*.jar` files (e.g. the WPS extension) in the `additional_libs` folder and build with one of the commands from above! (They will be copied to the GeoServer `WEB-INF/lib` folder during the build.)
-
-**Note:** Similar to the GeoServer data path from above, you can also configure the path to the additional libraries by passing the `ADDITIONAL_LIBS_PATH` argument when building:
-
-```shell
-docker build \
-  --build-arg ADDITIONAL_LIBS_PATH={RELATIVE_PATH_TO_YOUR_LIBS}
-  -t {YOUR_TAG} .
-```
-
-## How to release?
-
-### How to publish official release?
-
-OSGeo maintains geoserver-docker.osgeo.org repository for publishing. The results are combined into docker.osgeo.org repository alongside other software such as PostGIS.
-
-Build locally:
-
-```shell
-docker build -t geoserver-docker.osgeo.org/geoserver:2.22.0 .
-```
-
-Login using with osgeo user id:
-
-```shell
-docker login geoserver-docker.osgeo.org
-```
-
-Push to osgeo repository:
-
-```shell
-docker push geoserver-docker.osgeo.org/geoserver:2.22.0
-```
-
-### How to automate release?
-
-For CI purposes, the script in the `build` folder is used to simplify those steps.
-
-The variables `DOCKERUSER` and `DOCKERPASSWORD` have to be set with valid credentials before this script can push the image to the osgeo repo.
-
-You need to pass the version as first and the type as second argument, where type has to be one of `build`, `publish` or `buildandpublish`.
-
-Examples:
-
-`./release.sh 2.22.1 build`
-
-`./release.sh 2.22.0 publish`
-
-`./release.sh 2.22.1 buildandpublish`

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ This README.md file covers use of official docker image, additional [build](BULD
 To pull an official image use ``docker.osgeo.org/geoserver:{{VERSION}}``, e.g.:
 
 ```shell
-docker pull docker.osgeo.org/geoserver:2.22.0
+docker pull docker.osgeo.org/geoserver:2.23.0
 ```
 
 Afterwards you can run the pulled image locally with:
 
 ```shell
-docker run -it -p 80:8080 docker.osgeo.org/geoserver:2.22.0
+docker run -it -p 80:8080 docker.osgeo.org/geoserver:2.23.0
 ```
 
 Or if you want to start the container daemonized, use e.g.:
 
 ```shell
-docker run -d -p 80:8080 docker.osgeo.org/geoserver:2.22.0
+docker run -d -p 80:8080 docker.osgeo.org/geoserver:2.23.0
 ```
 
 Check <http://localhost/geoserver> to see the geoserver page,
@@ -47,7 +47,7 @@ To use an external folder as your geoserver data directory.
 ```shell
 docker run -it -p 80:8080 \
   --mount src="/absolute/path/on/host",target=/opt/geoserver_data/,type=bind \
-  docker.osgeo.org/geoserver:2.22.0
+  docker.osgeo.org/geoserver:2.23.0
 ```
 
 An empty data directory will be populated on first use. You can easily update GeoServer while
@@ -62,7 +62,7 @@ The environment variable `SKIP_DEMO_DATA` can be set to `true` to create an empt
 ```shell
 docker run -it -p 80:8080 \
   --env SKIP_DEMO_DATA=true \
-  docker.osgeo.org/geoserver:2.22.0
+  docker.osgeo.org/geoserver:2.23.0
 ```
 
 ## How to issue a redirect from the root ("/") to GeoServer web interface ("/geoserver/web")?
@@ -83,7 +83,7 @@ Example installing wps and ysld extensions:
 ```shell
 docker run -it -p 80:8080 \
   --env INSTALL_EXTENSIONS=true --env STABLE_EXTENSIONS="wps,ysld" \
-  docker.osgeo.org/geoserver:2.22.0
+  docker.osgeo.org/geoserver:2.23.0
 ```
 
 The list of extensions (taken from SourceForge download page):
@@ -108,7 +108,7 @@ If you want to add geoserver extensions/libs, place the respective jar files in 
 ```shell
 docker run -it -p 80:8080 \
   --mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind \
-  docker.osgeo.org/geoserver:2.22.0
+  docker.osgeo.org/geoserver:2.23.0
 ```
 
 ## How to add additional fonts to the docker image (e.g. for SLD styling)?
@@ -118,7 +118,7 @@ If you want to add custom fonts (the base image only contains 26 fonts) by using
 ```shell
 docker run -it -p 80:8080 \
   --mount src="/dir/with/fonts/on/host",target=/opt/additional_fonts,type=bind \
-  docker.osgeo.org/geoserver:2.22.0
+  docker.osgeo.org/geoserver:2.23.0
 ```
 
 **Note:** Do not change the target value!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,39 @@
+# Release Process
+
+## How to publish official release?
+
+OSGeo maintains geoserver-docker.osgeo.org repository for publishing. The results are combined into docker.osgeo.org repository alongside other software such as PostGIS.
+
+Build locally:
+
+```shell
+docker build -t geoserver-docker.osgeo.org/geoserver:2.22.0 .
+```
+
+Login using with osgeo user id:
+
+```shell
+docker login geoserver-docker.osgeo.org
+```
+
+Push to osgeo repository:
+
+```shell
+docker push geoserver-docker.osgeo.org/geoserver:2.22.0
+```
+
+## How to automate release?
+
+For CI purposes, the script in the `build` folder is used to simplify those steps.
+
+The variables `DOCKERUSER` and `DOCKERPASSWORD` have to be set with valid credentials before this script can push the image to the osgeo repo.
+
+You need to pass the version as first and the type as second argument, where type has to be one of `build`, `publish` or `buildandpublish`.
+
+Examples:
+
+`./release.sh 2.22.1 build`
+
+`./release.sh 2.22.0 publish`
+
+`./release.sh 2.22.1 buildandpublish`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -37,3 +37,5 @@ Examples:
 `./release.sh 2.22.0 publish`
 
 `./release.sh 2.22.1 buildandpublish`
+
+`./release.sh 2.24-SNAPSHOT buildandpublish`

--- a/build/release.sh
+++ b/build/release.sh
@@ -5,7 +5,7 @@ set -e
 
 function usage() {
   echo "$0 [options] <version>"
-  echo " version : The released version to build an docker image for (eg: 2.1.4)"
+  echo " version : The released version to build an docker image for (eg: 2.23.1, 2.24-SNAPSHOT)"
   echo " mode : The mode. Choose one of 'build', 'publish' or 'buildandpublish'"
 }
 
@@ -15,18 +15,56 @@ if [ -z $1 ] || [ -z $2 ] || [[ $2 != "build" && $2 != "publish" && $2 != "build
 fi
 
 VERSION=$1
-TAG=geoserver-docker.osgeo.org/geoserver:$VERSION
+MAIN="2.24"
+if [[ "${VERSION:0:4}" == "$MAIN" ]]; then
+  # main branch snapshot release
+  BRANCH=main
+  TAG=geoserver-docker.osgeo.org/geoserver:$MAIN.x
+else
+  if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
+    # stable or maintenance branch snapshot release
+    BRANCH="${VERSION:0:4}.x"
+    TAG=geoserver-docker.osgeo.org/geoserver:$BRANCH
+  else
+    BRANCH="${VERSION:0:4}.x"
+    TAG=geoserver-docker.osgeo.org/geoserver:$VERSION
+  fi
+fi
+
+echo "Release from branch $BRANCH GeoServer $VERSION as $TAG" 
 
 # Go up one level to the Dockerfile
 cd ".."
 
-if [ $2 != "publish" ]; then
+if [ $2 == *"build"* ]; then
   echo "Building GeoServer Docker Image..."
-  echo "docker build --build-arg GS_VERSION=$VERSION -t $TAG ."
-  docker build --build-arg GS_VERSION=$VERSION -t $TAG .
+  if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
+    echo "  nightly build from https://build.geoserver.org/geoserver/$BRANCH"
+    echo
+    if [[ "$BRANCH" == "main" ]]; then
+      echo "docker build --build-arg GS_VERSION=$VERSION -t $TAG ."
+      docker build \
+        --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip \
+        --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/main/ext-latest/ \
+        --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest/ \
+        --build-arg GS_VERSION=$VERSION \
+        -t $TAG .
+    else
+      echo "docker build --build-arg GS_VERSION=$VERSION -t $TAG ."
+      docker build \
+        --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip \
+        --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/ext-latest/ \
+        --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/community-latest/ \
+        --build-arg GS_VERSION=$VERSION \
+        -t $TAG .
+    fi
+  else
+    echo "docker build --build-arg GS_VERSION=$VERSION -t $TAG ."
+    docker build --build-arg GS_VERSION=$VERSION -t $TAG .
+  fi
 fi
 
-if [ $2 != "build" ]; then
+if [ $2 == *"publish"* ]; then
   echo "Publishing GeoServer Docker Image..."
   echo $DOCKERPASSWORD | docker login -u $DOCKERUSER --password-stdin geoserver-docker.osgeo.org
   echo "docker push $TAG"

--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -28,12 +28,16 @@ if [ "$INSTALL_EXTENSIONS" = "true" ]; then
     URL="${STABLE_PLUGIN_URL}/geoserver-${GEOSERVER_VERSION}-${EXTENSION}-plugin.zip"
     download_extension ${URL} ${EXTENSION}
   done
+  for EXTENSION in $(echo "${COMMUNITY_EXTENSIONS}" | tr ',' ' '); do
+    URL="${COMMUNITY_PLUGIN_URL}/geoserver-${GEOSERVER_VERSION}-${EXTENSION}-plugin.zip"
+    download_extension ${URL} ${EXTENSION}
+  done
   echo "Finished download of extensions"
 fi
 
 # Install the extensions
 echo "Starting installation of extensions"
-for EXTENSION in $(echo "${STABLE_EXTENSIONS}" | tr ',' ' '); do
+for EXTENSION in $(echo "${STABLE_EXTENSIONS},${COMMUNITY_EXTENSIONS}" | tr ',' ' '); do
   ADDITIONAL_LIB=${ADDITIONAL_LIBS_DIR}geoserver-${GEOSERVER_VERSION}-${EXTENSION}-plugin.zip
   [ -e "$ADDITIONAL_LIB" ] || continue
 


### PR DESCRIPTION
This pull-request provides support for nightly builds allowing the testing of community modules:

Here is a working example for building main branch as 2.24.x build:

```
docker build \
  --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip \
  --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/main/ext-latest/ \
  --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest/ \
  --build-arg GS_VERSION=2.24-SNAPSHOT \
  -t 2.24.x .
```

When running both [stable extensions](https://build.geoserver.org/geoserver/main/ext-latest/) and [community modules](https://build.geoserver.org/geoserver/main/community-latest/) can be included:

```
docker run -it -p 80:8080 \
  --env INSTALL_EXTENSIONS=true \
  --env STABLE_EXTENSIONS="wps,css" \
  --env COMMUNITY_EXTENSIONS="ogcapi-coverages,ogcapi-dggs,ogcapi-features,ogcapi-images,ogcapi-maps,ogcapi-styles,ogcapi-tiled-features,ogcapi-tiles" \
  -t 2.24.x
```

The ``release.sh`` script has been updated with the above examples in mind. We will require the creation of an additional build job to update stable tags for ``2.24.x``, ``2.23.x``, ``2.22.x`` on a going basis. This practice mitigates the risk of a ``war`` from one nightly build, being used with an extensions or community modules from a subsequent nightly build.
