### PR TITLE
Graceful tomcat shutdown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,6 +89,6 @@ RUN apt purge -y && \
 COPY *.sh /opt/
 RUN chmod +x /opt/*.sh
 
-ENTRYPOINT /opt/startup.sh
+ENTRYPOINT ["/opt/startup.sh"]
 
 WORKDIR /opt

--- a/startup.sh
+++ b/startup.sh
@@ -79,4 +79,4 @@ if [ "${CORS_ENABLED}" = "true" ]; then
 fi
 
 # start the tomcat
-$CATALINA_HOME/bin/catalina.sh run
+exec $CATALINA_HOME/bin/catalina.sh run


### PR DESCRIPTION
Hi community,

I'd like to propose this enhancement.

Expected behaviour:
Graceful tomcat shutdown when the container should stop, without delay .

Current behaviour:
The tomcat is killed instead of being shut down, after a delay.

Reason: 
The java process is not process 1 within the container, because of an intermediate shell:

```
F S UID          PID    PPID  C PRI  NI ADDR SZ WCHAN  STIME TTY          TIME CMD
4 S root           1       0  0  80   0 -   722 do_wai 17:02 ?        00:00:00 /bin/sh -c /opt/startup.sh
0 S root           2       1 94  80   0 - 926044 futex_ 17:02 ?       00:00:25 /usr/bin/java -Djava.util.logging.config.file=/opt/apache-tomcat-9.0.68/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogMan
```

Consequence: The SIGTERM signal issued by for example "docker stop <cid>" is received by startup.sh instead of the JVM. So the tomcat is not notified to shut down gracefully. Instead a later SIGKILL will kill the shell and the tomcat child process, after a delay of typically 10sec.

This PR results in the following process structure:

```
F S UID          PID    PPID  C PRI  NI ADDR SZ WCHAN  STIME TTY          TIME CMD
4 S root           1       0 99  80   0 - 925788 futex_ 17:17 ?       00:00:24 /usr/bin/java -Djava.util.logging.config.file=/opt/apache-tomcat-9.0.68/conf/logging.properties -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogMan
```

Two small enhancements are necessary to achieve this:

* in /startup.sh execute the JVM with "exec" to replace to shell process
* use the "shell form" of the entrypoint directive in the Dockerfile, see https://docs.docker.com/engine/reference/builder/#exec-form-entrypoint-example

Thank you for considering this.

Best regards,
Andreas
