### PR TITLE
[GEOS-11016] Use multi-stage build to avoid caching snapshot download

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -65,10 +65,9 @@ Override these arguments to make use of build.geoserver.org nightly releases:
 * ``--build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/${GS_VERSION}/ext-latest/``
 * ``--build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/${GS_VERSION}/community-latest/``
 
-
 Here is a working example for building 2.23.x nightly build::
 ```
-docker build \
+docker build --no-cache-filter download,install \
   --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/2.23.x/geoserver-2.23.x-latest-war.zip \
   --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/2.23.x/ext-latest/ \
   --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/2.23.x/community-latest/ \
@@ -100,7 +99,7 @@ The build.geoserver.org output for the ``main`` branch requires the following:
 Here is a working example for building main branch as 2.24.x build:
 
 ```
-docker build \
+docker build --no-cache-filter download,install \
   --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip \
   --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/main/ext-latest/ \
   --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,42 +1,19 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 as tomcat
 
-# The GS_VERSION argument could be used like this to overwrite the default:
-# docker build --build-arg GS_VERSION=2.23.0 -t geoserver:2.23.0 .
-ARG TOMCAT_VERSION=9.0.74
-ARG GS_VERSION=2.23.0
-ARG GS_DATA_PATH=./geoserver_data/
-ARG ADDITIONAL_LIBS_PATH=./additional_libs/
-ARG ADDITIONAL_FONTS_PATH=./additional_fonts/
+ARG TOMCAT_VERSION=9.0.75
 ARG CORS_ENABLED=false
 ARG CORS_ALLOWED_ORIGINS=*
 ARG CORS_ALLOWED_METHODS=GET,POST,PUT,DELETE,HEAD,OPTIONS
 ARG CORS_ALLOWED_HEADERS=*
-ARG WAR_ZIP_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
-ARG STABLE_PLUGIN_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/extensions
-ARG COMMUNITY_PLUGIN_URL=''
 
 # Environment variables
 ENV CATALINA_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
-ENV GEOSERVER_VERSION=$GS_VERSION
-ENV GEOSERVER_DATA_DIR=/opt/geoserver_data/
-ENV GEOSERVER_REQUIRE_FILE=$GEOSERVER_DATA_DIR/global.xml
-ENV GEOSERVER_LIB_DIR=$CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
 ENV EXTRA_JAVA_OPTS="-Xms256m -Xmx1g"
 ENV CORS_ENABLED=$CORS_ENABLED
 ENV CORS_ALLOWED_ORIGINS=$CORS_ALLOWED_ORIGINS
 ENV CORS_ALLOWED_METHODS=$CORS_ALLOWED_METHODS
 ENV CORS_ALLOWED_HEADERS=$CORS_ALLOWED_HEADERS
 ENV DEBIAN_FRONTEND=noninteractive
-ENV INSTALL_EXTENSIONS=false
-ENV WAR_ZIP_URL=$WAR_ZIP_URL
-ENV STABLE_EXTENSIONS=''
-ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
-ENV COMMUNITY_EXTENSIONS=''
-ENV COMMUNITY_PLUGIN_URL=$COMMUNITY_PLUGIN_URL
-ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
-ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
-ENV SKIP_DEMO_DATA=false
-ENV ROOT_WEBAPP_REDIRECT=false
 
 # see https://docs.geoserver.org/stable/en/user/production/container.html
 ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
@@ -50,40 +27,99 @@ ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
     -Dorg.geotools.coverage.jaiext.enabled=true"
 
 # init
-RUN apt update && \
-    apt -y upgrade && \
-    apt install -y --no-install-recommends openssl unzip gdal-bin wget curl openjdk-11-jdk && \
-    apt clean && \
-    rm -rf /var/cache/apt/* && \
-    rm -rf /var/lib/apt/lists/*
+RUN <<EOF
+set -e
+apt update
+apt -y upgrade
+apt install -y --no-install-recommends openssl unzip gdal-bin wget curl openjdk-11-jdk
+apt clean
+rm -rf /var/cache/apt/*
+rm -rf /var/lib/apt/lists/*
+EOF
 
 WORKDIR /opt/
-RUN wget -q https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
-    tar xf apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
-    rm apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
-    rm -rf /opt/apache-tomcat-${TOMCAT_VERSION}/webapps/ROOT && \
-    rm -rf /opt/apache-tomcat-${TOMCAT_VERSION}/webapps/docs && \
-    rm -rf /opt/apache-tomcat-${TOMCAT_VERSION}/webapps/examples
+
+RUN <<EOF
+set -e
+wget -q https://archive.apache.org/dist/tomcat/tomcat-9/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz
+tar xf apache-tomcat-${TOMCAT_VERSION}.tar.gz
+rm apache-tomcat-${TOMCAT_VERSION}.tar.gz
+rm -rf /opt/apache-tomcat-${TOMCAT_VERSION}/webapps/ROOT
+rm -rf /opt/apache-tomcat-${TOMCAT_VERSION}/webapps/docs
+rm -rf /opt/apache-tomcat-${TOMCAT_VERSION}/webapps/examples
+EOF
+
+# cleanup
+RUN <<EOF
+set -e
+apt purge -y && \
+apt autoremove --purge -y && \
+rm -rf /tmp/*
+EOF
+
+FROM tomcat as download
+
+ARG GS_VERSION=2.23.1
+ARG GS_BUILD=''
+ARG WAR_ZIP_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
+ENV GEOSERVER_VERSION=$GS_VERSION
+ENV GEOSERVER_BUILD=$GS_BUILD
+
+WORKDIR /tmp
+
+RUN <<EOF
+set -e
+echo "Downloading GeoServer ${GEOSERVER_VERSION} ${GEOSERVER_BUILD}"
+wget -q -O /tmp/geoserver.zip $WAR_ZIP_URL
+unzip geoserver.zip geoserver.war -d /tmp/
+unzip -q /tmp/geoserver.war -d /tmp/geoserver
+rm /tmp/geoserver.war
+EOF
+
+FROM tomcat as install
+
+ARG GS_VERSION=2.23.1
+ARG GS_BUILD=''
+ARG STABLE_PLUGIN_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/extensions
+ARG COMMUNITY_PLUGIN_URL=''
+
+ARG GS_DATA_PATH=./geoserver_data/
+ARG ADDITIONAL_LIBS_PATH=./additional_libs/
+ARG ADDITIONAL_FONTS_PATH=./additional_fonts/
+
+ENV GEOSERVER_VERSION=$GS_VERSION
+ENV GEOSERVER_BUILD=$GS_BUILD
+ENV GEOSERVER_DATA_DIR=/opt/geoserver_data/
+ENV GEOSERVER_REQUIRE_FILE=$GEOSERVER_DATA_DIR/global.xml
+ENV GEOSERVER_LIB_DIR=$CATALINA_HOME/webapps/geoserver/WEB-INF/lib/
+ENV INSTALL_EXTENSIONS=false
+ENV WAR_ZIP_URL=$WAR_ZIP_URL
+ENV STABLE_EXTENSIONS=''
+ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
+ENV COMMUNITY_EXTENSIONS=''
+ENV COMMUNITY_PLUGIN_URL=$COMMUNITY_PLUGIN_URL
+ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
+ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
+ENV SKIP_DEMO_DATA=false
+ENV ROOT_WEBAPP_REDIRECT=false
 
 WORKDIR /tmp
 
 # install geoserver
-RUN wget -q -O /tmp/geoserver.zip $WAR_ZIP_URL && \
-    unzip geoserver.zip geoserver.war -d $CATALINA_HOME/webapps && \
-    mkdir -p $CATALINA_HOME/webapps/geoserver && \
-    unzip -q $CATALINA_HOME/webapps/geoserver.war -d $CATALINA_HOME/webapps/geoserver && \
-    rm $CATALINA_HOME/webapps/geoserver.war && \
-    mv $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/marlin-0.9.3.jar $CATALINA_HOME/lib/marlin.jar && \
-    mkdir -p $GEOSERVER_DATA_DIR
+COPY --from=download /tmp/geoserver $CATALINA_HOME/webapps/geoserver
+
+RUN <<EOF
+set -e
+mv $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/marlin-*.jar $CATALINA_HOME/lib/marlin.jar
+mkdir -p $GEOSERVER_DATA_DIR
+EOF
 
 COPY $GS_DATA_PATH $GEOSERVER_DATA_DIR
 COPY $ADDITIONAL_LIBS_PATH $GEOSERVER_LIB_DIR
 COPY $ADDITIONAL_FONTS_PATH /usr/share/fonts/truetype/
 
 # cleanup
-RUN apt purge -y && \
-    apt autoremove --purge -y && \
-    rm -rf /tmp/*
+RUN rm -rf /tmp/*
 
 # copy scripts
 COPY *.sh /opt/

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ This README.md file covers use of official docker image, additional [build](BULD
 To pull an official image use ``docker.osgeo.org/geoserver:{{VERSION}}``, e.g.:
 
 ```shell
-docker pull docker.osgeo.org/geoserver:2.23.0
+docker pull docker.osgeo.org/geoserver:2.23.1
 ```
 
 Afterwards you can run the pulled image locally with:
 
 ```shell
-docker run -it -p 80:8080 docker.osgeo.org/geoserver:2.23.0
+docker run -it -p 80:8080 docker.osgeo.org/geoserver:2.23.1
 ```
 
 Or if you want to start the container daemonized, use e.g.:
 
 ```shell
-docker run -d -p 80:8080 docker.osgeo.org/geoserver:2.23.0
+docker run -d -p 80:8080 docker.osgeo.org/geoserver:2.23.1
 ```
 
 Check <http://localhost/geoserver> to see the geoserver page,
@@ -47,7 +47,7 @@ To use an external folder as your geoserver data directory.
 ```shell
 docker run -it -p 80:8080 \
   --mount src="/absolute/path/on/host",target=/opt/geoserver_data/,type=bind \
-  docker.osgeo.org/geoserver:2.23.0
+  docker.osgeo.org/geoserver:2.23.1
 ```
 
 An empty data directory will be populated on first use. You can easily update GeoServer while
@@ -62,7 +62,7 @@ The environment variable `SKIP_DEMO_DATA` can be set to `true` to create an empt
 ```shell
 docker run -it -p 80:8080 \
   --env SKIP_DEMO_DATA=true \
-  docker.osgeo.org/geoserver:2.23.0
+  docker.osgeo.org/geoserver:2.23.1
 ```
 
 ## How to issue a redirect from the root ("/") to GeoServer web interface ("/geoserver/web")?
@@ -83,7 +83,7 @@ Example installing wps and ysld extensions:
 ```shell
 docker run -it -p 80:8080 \
   --env INSTALL_EXTENSIONS=true --env STABLE_EXTENSIONS="wps,ysld" \
-  docker.osgeo.org/geoserver:2.23.0
+  docker.osgeo.org/geoserver:2.23.1
 ```
 
 The list of extensions (taken from SourceForge download page):
@@ -108,7 +108,7 @@ If you want to add geoserver extensions/libs, place the respective jar files in 
 ```shell
 docker run -it -p 80:8080 \
   --mount src="/dir/with/libs/on/host",target=/opt/additional_libs,type=bind \
-  docker.osgeo.org/geoserver:2.23.0
+  docker.osgeo.org/geoserver:2.23.1
 ```
 
 ## How to add additional fonts to the docker image (e.g. for SLD styling)?
@@ -118,7 +118,7 @@ If you want to add custom fonts (the base image only contains 26 fonts) by using
 ```shell
 docker run -it -p 80:8080 \
   --mount src="/dir/with/fonts/on/host",target=/opt/additional_fonts,type=bind \
-  docker.osgeo.org/geoserver:2.23.0
+  docker.osgeo.org/geoserver:2.23.1
 ```
 
 **Note:** Do not change the target value!

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ OSGeo maintains geoserver-docker.osgeo.org repository for publishing. The result
 Build locally:
 
 ```shell
-docker build -t geoserver-docker.osgeo.org/geoserver:2.22.0 .
+docker build -t geoserver-docker.osgeo.org/geoserver:2.23.1 .
 ```
 
 Login using with osgeo user id:
@@ -19,7 +19,7 @@ docker login geoserver-docker.osgeo.org
 Push to osgeo repository:
 
 ```shell
-docker push geoserver-docker.osgeo.org/geoserver:2.22.0
+docker push geoserver-docker.osgeo.org/geoserver:2.23.1
 ```
 
 ## How to automate release?
@@ -34,7 +34,7 @@ Examples:
 
 `./release.sh 2.22.1 build`
 
-`./release.sh 2.22.0 publish`
+`./release.sh 2.23.1 publish`
 
 `./release.sh 2.22.1 buildandpublish`
 


### PR DESCRIPTION
Docker is caching the download step and is not noticing when new war is available for download. This leads to the **geoserver.war** being out of sync with the extensions and community modules installed.

The Dockerfile has three stages:
- tomcat
- download
- install

For a nightly build run with ``--no-cache-filter '!tomcat'`` to avoid caching download and install stages.