### PR TITLE
org.marlin.pisces to sun.java2d.marlin 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
     -Djavax.servlet.response.encoding=UTF-8 \
     -D-XX:SoftRefLRUPolicyMSPerMB=36000 \
     -Xbootclasspath/a:$CATALINA_HOME/lib/marlin.jar \
-    -Dsun.java2d.renderer=org.marlin.pisces.PiscesRenderingEngine \
+    -Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine \
     -Dorg.geotools.coverage.jaiext.enabled=true"
 
 # init


### PR DESCRIPTION
Hi, 
 as of https://github.com/bourgesl/marlin-renderer/releases isn't it better to use 
`-Dsun.java2d.renderer=sun.java2d.marlin.DMarlinRenderingEngine` with openjdk11 ?


 ref: https://www.geocat.net/docs/geoserver-enterprise/2020.5/install/production/marlin.html#check-rendering-engine

Java | Rendering Engine | Recommendation
-- | -- | --
Java 8 | sun.dc.DuctusRenderingEngine | This is the Java 8 default rendering engine, recommend installing Marlin.
Java 8 | org.marlin.pisces.MarlinRenderingEngine | Correctly configured with Marlin Rendering Engine
Java 11 | sun.java2d.marlin.DMarlinRenderingEngine | Java 11 defaults to MarlinRenderingEngine

