### PR TITLE
Allow setting proxy base URL in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,13 @@ The environment variable `ROOT_WEBAPP_REDIRECT` can be set to `true` to issue a 
 
 The ``startup.sh`` script allows some customization on startup:
 
-* ``INSTALL_EXTENSIONS`` to ``true`` to download and install extensions
-* ``STABLE_EXTENSIONS`` list of extensions to download and install
-* ``CORS_ENABLED``
+* ``INSTALL_EXTENSIONS`` to ``true`` to download and install extensions.
+* ``STABLE_EXTENSIONS`` list of extensions to download and install.
+* ``CORS_ENABLED`` to ``true`` to enable CORS support. The following environment variables can be used to customize the CORS configuration.
+  * ``CORS_ALLOWED_ORIGINS`` (default ``*``)
+  * ``CORS_ALLOWED_METHODS`` (default ``GET,POST,PUT,DELETE,HEAD,OPTIONS``)
+  * ``CORS_ALLOWED_HEADERS`` (default ``*``)
+* ``PROXY_BASE_URL`` to the base URL of the GeoServer web app if GeoServer is behind a proxy. Example: ``https://example.com/geoserver``.
 
 Example installing wps and ysld extensions:
 

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 echo "Welcome to GeoServer $GEOSERVER_VERSION"
 
+GEOSERVER_WEB_XML="$CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml"
+
 ## Skip demo data
 if [ "${SKIP_DEMO_DATA}" = "true" ]; then
   unset GEOSERVER_REQUIRE_FILE
@@ -52,8 +54,8 @@ fi
 # to the end of the web.xml
 # (this will only happen if our filter has not yet been added before)
 if [ "${CORS_ENABLED}" = "true" ]; then
-  if ! grep -q DockerGeoServerCorsFilter "$CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml"; then
-    echo "Enable CORS for $CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml"
+  if ! grep -q DockerGeoServerCorsFilter "${GEOSERVER_WEB_XML}"; then
+    echo "Enable CORS for ${GEOSERVER_WEB_XML}"
     sed -i "\:</web-app>:i\\
     <filter>\n\
       <filter-name>DockerGeoServerCorsFilter</filter-name>\n\
@@ -74,7 +76,19 @@ if [ "${CORS_ENABLED}" = "true" ]; then
     <filter-mapping>\n\
       <filter-name>DockerGeoServerCorsFilter</filter-name>\n\
       <url-pattern>/*</url-pattern>\n\
-    </filter-mapping>" "$CATALINA_HOME/webapps/geoserver/WEB-INF/web.xml";
+    </filter-mapping>" "${GEOSERVER_WEB_XML}"
+  fi
+fi
+
+if [ -n "${PROXY_BASE_URL}" ]; then
+  if ! grep -q StartupProxyBaseUrl "${GEOSERVER_WEB_XML}"; then
+    echo "Set proxy URL for ${GEOSERVER_WEB_XML}"
+    sed -i "\:</web-app>:i\\
+    <!-- StartupProxyBaseUrl -->\n\
+    <context-param>\n\
+      <param-name>PROXY_BASE_URL</param-name>\n\
+      <param-value>${PROXY_BASE_URL}</param-value>\n\
+    </context-param>" "${GEOSERVER_WEB_XML}"
   fi
 fi
 


### PR DESCRIPTION
When bringing GeoServer up behind a load balancer or proxy that does HTTPS termination, e.g., using Kubernetes or Amazon ECS, there's a bootstrapping problem: you can't log in as the admin to set the proxy URL until the proxy URL is already set because GeoServer thinks its URL is HTTP, not HTTPS.

Add support for configuring the proxy URL in `web.xml` using an environment variable.