### PR TITLE
Handle Release Candidate branches

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -9,7 +9,7 @@ function usage() {
   echo "$0 <mode> <version> [<build>]"
   echo ""
   echo " mode : The mode. Choose one of 'build', 'publish' or 'buildandpublish'"
-  echo " version : The released version to build an docker image for (eg: 2.23.1, ${MAIN}-SNAPSHOT)"
+  echo " version : The released version to build an docker image for (eg: 2.23.1, ${MAIN}-SNAPSHOT, ${MAIN}-RC)"
   echo " build : Build number (optional)"
 }
 
@@ -26,18 +26,24 @@ else
   BUILD=$3
 fi
 
-if [[ "${VERSION:0:4}" == "$MAIN" ]]; then
-  # main branch snapshot release
-  BRANCH=main
-  TAG=geoserver-docker.osgeo.org/geoserver:$MAIN.x
+if [[ "$VERSION" == *"-RC"* ]]; then
+  	# release candidate branch release
+  	BRANCH="${VERSION:0:4}-RC"
+  	TAG=geoserver-docker.osgeo.org/geoserver:$BRANCH
 else
-  if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
-    # stable or maintenance branch snapshot release
-    BRANCH="${VERSION:0:4}.x"
-    TAG=geoserver-docker.osgeo.org/geoserver:$BRANCH
+  if [[ "${VERSION:0:4}" == "$MAIN" ]]; then
+    # main branch snapshot release
+    BRANCH=main
+    TAG=geoserver-docker.osgeo.org/geoserver:$MAIN.x
   else
-    BRANCH="${VERSION:0:4}.x"
-    TAG=geoserver-docker.osgeo.org/geoserver:$VERSION
+    if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
+  	# stable or maintenance branch snapshot release
+  	BRANCH="${VERSION:0:4}.x"
+  	TAG=geoserver-docker.osgeo.org/geoserver:$BRANCH
+    else
+  	BRANCH="${VERSION:0:4}.x"
+  	TAG=geoserver-docker.osgeo.org/geoserver:$VERSION
+    fi
   fi
 fi
 


### PR DESCRIPTION
As per email: `[Geoserver-users] GeoServer 2.24-RC released. Please help us test it`, Andrea says:

```
If I remember correctly, we have had some issue with the docker release script
not handling RC correctly? Like, it's not doing the right thing when it sees "2.24-RC" in the version
and ended up tagging it as part of 2.24.x instead (which I assume has been overwritten by a proper
nightly build by now).
```
This PR adds support for the `-RC` branches.

The publish mode has not been tested due to lack of geoserver-docker.osgeo.org credentials