### PR TITLE
Added support for a PostgreSQL JNDI resource.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
 # init
 RUN apt update \
 && apt -y upgrade \
-&& apt install -y --no-install-recommends openssl unzip gdal-bin wget curl openjdk-11-jdk \
+&& apt install -y --no-install-recommends openssl unzip gdal-bin wget curl openjdk-11-jdk gettext \
 && apt clean \
 && rm -rf /var/cache/apt/* \
 && rm -rf /var/lib/apt/lists/*
@@ -92,6 +92,9 @@ ENV ADDITIONAL_LIBS_DIR=/opt/additional_libs/
 ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
 ENV SKIP_DEMO_DATA=false
 ENV ROOT_WEBAPP_REDIRECT=false
+ENV POSTGRES_JNDI_ENABLED=false
+ENV CONFIG_DIR=/opt/config
+ENV CONFIG_OVERRIDES_DIR=/opt/config_overrides
 
 EXPOSE 8080
 
@@ -104,12 +107,17 @@ COPY --from=download /tmp/geoserver $CATALINA_HOME/webapps/geoserver
 RUN mv $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/marlin-*.jar $CATALINA_HOME/lib/marlin.jar \
 && mkdir -p $GEOSERVER_DATA_DIR
 
+RUN mv $CATALINA_HOME/webapps/geoserver/WEB-INF/lib/postgresql-*.jar $CATALINA_HOME/lib/
+
 COPY $GS_DATA_PATH $GEOSERVER_DATA_DIR
 COPY $ADDITIONAL_LIBS_PATH $GEOSERVER_LIB_DIR
 COPY $ADDITIONAL_FONTS_PATH /usr/share/fonts/truetype/
 
 # cleanup
 RUN rm -rf /tmp/*
+
+# Add default configs
+ADD config $CONFIG_DIR
 
 # copy scripts
 COPY *.sh /opt/

--- a/README.md
+++ b/README.md
@@ -128,6 +128,22 @@ docker run -it -p 80:8080 \
 
 **Note:** Do not change the target value!
 
+
+## How to enable a PostgreSQL JNDI resource?
+
+To enable a PostgreSQL JNDI resource, provide the following environment variables:
+
+* ``POSTGRES_JNDI_ENABLED`` to ``true``
+* ``POSTGRES_HOST``
+* ``POSTGRES_PORT`` (optional; defaults to 5432)
+* ``POSTGRES_DB``
+* ``POSTGRES_USERNAME``
+* ``POSTGRES_PASSWORD``
+* ``POSTGRES_JNDI_RESOURCE_NAME`` (optional; defaults to ``java:comp/env/jdbc/postgres``)
+
+For advanced customization of the connection pool, you can provide your own customized "context.xml"
+file to Apache Tomcat by mounting it to the container at ``/opt/config_overrides/context.xml``.
+
 ## How to use the docker-compose demo?
 
 The ``docker-compose-demo.yml`` to build with your own data directory and extensions.

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ To enable a PostgreSQL JNDI resource, provide the following environment variable
 * ``POSTGRES_DB``
 * ``POSTGRES_USERNAME``
 * ``POSTGRES_PASSWORD``
-* ``POSTGRES_JNDI_RESOURCE_NAME`` (optional; defaults to ``java:comp/env/jdbc/postgres``)
+* ``POSTGRES_JNDI_RESOURCE_NAME`` (optional; defaults to ``jdbc/postgres``)
+
+In geoserver, you can then reference this JNDI resource using the name `java:comp/env/jdbc/postgres` (if using default).
 
 For advanced customization of the connection pool, you can provide your own customized "context.xml"
 file to Apache Tomcat by mounting it to the container at ``/opt/config_overrides/context.xml``.

--- a/config/context.xml
+++ b/config/context.xml
@@ -1,0 +1,20 @@
+<Context antiResourceLocking="false" privileged="true" >
+    <Resource name="${POSTGRES_JNDI_RESOURCE_NAME}"
+              auth="Container"
+              type="javax.sql.DataSource"
+              driverClassName="org.postgresql.Driver"
+              url="jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
+              username="${POSTGRES_USERNAME}"
+              password="${POSTGRES_PASSWORD}"
+              maxTotal="8"
+              initialSize="0"
+              minIdle="0"
+              maxIdle="8"
+              maxWaitMillis="-1"
+              timeBetweenEvictionRunsMillis="30000"
+              minEvictableIdleTimeMillis="60000"
+              testWhileIdle="true"
+              validationQuery="SELECT 1"
+              rollbackOnReturn="true"
+    />
+</Context>

--- a/config/context.xml
+++ b/config/context.xml
@@ -6,7 +6,7 @@
               url="jdbc:postgresql://${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}"
               username="${POSTGRES_USERNAME}"
               password="${POSTGRES_PASSWORD}"
-              maxTotal="8"
+              maxTotal="25"
               initialSize="0"
               minIdle="0"
               maxIdle="8"

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -13,6 +13,22 @@ services:
       - INSTALL_EXTENSIONS=true
       - STABLE_EXTENSIONS=wps,csw
       - EXTRA_JAVA_OPTS=-Xms1G -Xmx2G
+      - POSTGRES_JNDI_ENABLED=true
+      - POSTGRES_HOST=postgis
+      - POSTGRES_PORT=5432
+      - POSTGRES_DB=geoserver
+      - POSTGRES_USERNAME=geoserver
+      - POSTGRES_PASSWORD=geoserver
+      - POSTGRES_JNDI_RESOURCE_NAME=jdbc/postgres
     volumes:
       - ./geoserver_data:/opt/geoserver_data/:Z
       - ./additional_libs:/opt/additional_libs:Z # by mounting this we can install libs from host on startup
+  postgis:
+    image: postgis/postgis:16-3.4-alpine
+    ports:
+      - 5555:5432
+    environment:
+      POSTGRES_USER: geoserver
+      POSTGRES_PASSWORD: geoserver
+    volumes:
+      - ./postgis/postgresql_data:/var/lib/postgresql/data:Z

--- a/startup.sh
+++ b/startup.sh
@@ -90,5 +90,26 @@ if [ "${CORS_ENABLED}" = "true" ]; then
   fi
 fi
 
+if [ "${POSTGRES_JNDI_ENABLED}" = "true" ]; then
+
+  # Set up some default values
+  if [ -z "${POSTGRES_JNDI_RESOURCE_NAME}" ]; then
+    export POSTGRES_JNDI_RESOURCE_NAME="java:comp/env/jdbc/postgres"
+  fi
+  if [ -z "${POSTGRES_PORT}" ]; then
+    export POSTGRES_PORT="5432"
+  fi
+
+  # Use a custom "context.xml" if the user mounted one into the container
+  if [ -d "${CONFIG_OVERRIDES_DIR}" ] && [ -f "${CONFIG_OVERRIDES_DIR}/context.xml" ]; then
+    echo "Installing configuration override for context.xml with substituted environment variables"
+    envsubst < "${CONFIG_OVERRIDES_DIR}"/context.xml > "${CATALINA_HOME}/conf/context.xml"
+  else
+    # Otherwise use the default
+    echo "Installing default context.xml with substituted environment variables"
+    envsubst < "${CONFIG_DIR}"/context.xml > "${CATALINA_HOME}/conf/context.xml"
+  fi
+fi
+
 # start the tomcat
 exec $CATALINA_HOME/bin/catalina.sh run

--- a/startup.sh
+++ b/startup.sh
@@ -94,7 +94,7 @@ if [ "${POSTGRES_JNDI_ENABLED}" = "true" ]; then
 
   # Set up some default values
   if [ -z "${POSTGRES_JNDI_RESOURCE_NAME}" ]; then
-    export POSTGRES_JNDI_RESOURCE_NAME="java:comp/env/jdbc/postgres"
+    export POSTGRES_JNDI_RESOURCE_NAME="jdbc/postgres"
   fi
   if [ -z "${POSTGRES_PORT}" ]; then
     export POSTGRES_PORT="5432"


### PR DESCRIPTION
This pull request adds support for creating a PostgreSQL JNDI resource in Apache Tomcat. 

- Included a blurb on the README.md on how to use.
- Provides a default "context.xml" that a user can easily configure using environment variables.
- Provides a mechanism for the user to override the default "context.xml" with their own version of the file for more advanced customization of the connection pool.

Heavily inspired by the work done at https://github.com/kartoza/docker-geoserver.