### PR TITLE
Implement EXPOSE port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ ENV ADDITIONAL_FONTS_DIR=/opt/additional_fonts/
 ENV SKIP_DEMO_DATA=false
 ENV ROOT_WEBAPP_REDIRECT=false
 
+EXPOSE 8080
+
 WORKDIR /tmp
 
 RUN echo "Installing GeoServer $GS_VERSION $GS_BUILD"


### PR DESCRIPTION
See https://docs.docker.com/engine/reference/builder/#expose

Otherwise Docker Desktop (Windows) does not know that any ports are exposed:

![image](https://github.com/geoserver/docker/assets/5699667/38c2f6df-02d7-4ccc-a28e-8d83f21850b9)
