### PR TITLE
fix: Use consistent version number in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN apt purge -y  \
 
 FROM tomcat as download
 
-ARG GS_VERSION=2.23.1
+ARG GS_VERSION=2.24.0
 ARG GS_BUILD=release
 ARG WAR_ZIP_URL=https://downloads.sourceforge.net/project/geoserver/GeoServer/${GS_VERSION}/geoserver-${GS_VERSION}-war.zip
 ENV GEOSERVER_VERSION=$GS_VERSION


### PR DESCRIPTION
Due to the use of the multistage build feature, we have multiple declarations of `GS_VERSION` in the Dockerfile. For some reason, this value diverged during the latest releases. This MR just fixes the value, but we should investigate the source of the problem and fix it in a follow up.