### PR TITLE
Docs: Add docker ENV vars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ docker-compose -f docker-compose-demo.yml up --build
 ```
 ## Environment Variables
 
-Following is the list of the all the environment variables that can be passed down to the geoserver docker image, you can check the defaul values for an image using `docker inspect [IMAGE_NAME]`
+Following is the list of the all the environment variables that can be passed down to the geoserver docker image, you can check the default values for an image using `docker inspect [IMAGE_NAME]`
 | VAR NAME | DESCRIPTION | SAMPLE VALUE |
 |--------------|-----------|------------|
 | PATH | Used by geoserver internally to find all the libs | `/usr/local/sbin:/usr/local/bin:` |
@@ -171,11 +171,8 @@ Following is the list of the all the environment variables that can be passed do
 | CORS_ALLOWED_HEADERS | CORS headers configuration | `*` |
 | DEBIAN_FRONTEND | Configures the Debian package manager frontend | `noninteractive`|
 | CATALINA_OPTS | Catalina options | `-Djava.awt.headless=true` |
-| GEOSERVER_VERSION | Geoserver version (used internally) | `2.24-SNAPSHOT`|
-| GEOSERVER_BUILD | Geosever build (used internally) | `1628` |
 | GEOSERVER_DATA_DIR | Geosever data directory location | `/opt/geoserver_data/` |
 | GEOSERVER_REQUIRE_FILE | Geoserver configuration used interally | `/opt/geoserver_data/global.xml` |
-| GEOSERVER_LIB_DIR | Sets the directory containing GeoServer's library files | `/opt/apache-tomcat-9.0.75/webapps/geoserver/WEB-INF/lib/` |
 | INSTALL_EXTENSIONS | Indicates whether additional GeoServer extensions should be installed | `false` |
 | WAR_ZIP_URL | Specifies the URL for a GeoServer Web Archive (WAR) file | |
 | STABLE_EXTENSIONS | Specifies stable GeoServer extensions | |
@@ -186,6 +183,12 @@ Following is the list of the all the environment variables that can be passed do
 | ADDITIONAL_FONTS_DIR | Sets the directory for additional fonts used by GeoServer | `/opt/additional_fonts/` |
 | SKIP_DEMO_DATA | Indicates whether to skip the installation of demo data provided by GeoServer | `false` |
 | ROOT_WEBAPP_REDIRECT | Indicates whether to issue a permanent redirect to the web interface | `false` |
+
+The following values cannot really be safely changed (as they are used to download extensions and community modules as the docker image first starts up).
+| VAR NAME | DESCRIPTION | SAMPLE VALUE |
+|--------------|-----------|------------|
+| GEOSERVER_VERSION | Geoserver version (used internally) | `2.24-SNAPSHOT`|
+| GEOSERVER_BUILD | Geosever build (used internally) | `1628` |
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To pull an official image use ``docker.osgeo.org/geoserver:{{VERSION}}``, e.g.:
 ```shell
 docker pull docker.osgeo.org/geoserver:2.23.1
 ```
+All the images can be found at: [https://repo.osgeo.org](https://repo.osgeo.org)
 
 Afterwards you can run the pulled image locally with:
 
@@ -164,13 +165,13 @@ Following is the list of the all the environment variables that can be passed do
 |--------------|-----------|------------|
 | PATH | Used by geoserver internally to find all the libs | `/usr/local/sbin:/usr/local/bin:` |
 | CATALINA_HOME | CATALINA home path | `/opt/apache-tomcat-9.0.75` |
-| EXTRA_JAVA_OPTS | Used to pass params to the JAVA environment | `-Xms256m -Xmx1g` |
+| EXTRA_JAVA_OPTS | Used to pass params to the JAVA environment. Check [ref](https://docs.oracle.com/en/java/javase/11/tools/java.html) | `-Xms256m -Xmx1g` |
 | CORS_ENABLED | CORS enabled configuration | `false` |
 | CORS_ALLOWED_ORIGINS | CORS origins configuration | `*` |
 | CORS_ALLOWED_METHODS | CORS method configuration | `GET,POST` |
 | CORS_ALLOWED_HEADERS | CORS headers configuration | `*` |
 | DEBIAN_FRONTEND | Configures the Debian package manager frontend | `noninteractive`|
-| CATALINA_OPTS | Catalina options | `-Djava.awt.headless=true` |
+| CATALINA_OPTS | Catalina options. Check [ref](https://www.baeldung.com/tomcat-catalina_opts-vs-java_opts) | `-Djava.awt.headless=true` |
 | GEOSERVER_DATA_DIR | Geosever data directory location | `/opt/geoserver_data/` |
 | GEOSERVER_REQUIRE_FILE | Geoserver configuration used interally | `/opt/geoserver_data/global.xml` |
 | INSTALL_EXTENSIONS | Indicates whether additional GeoServer extensions should be installed | `false` |

--- a/README.md
+++ b/README.md
@@ -157,6 +157,36 @@ Run ``docker-compose``:
 ```shell
 docker-compose -f docker-compose-demo.yml up --build
 ```
+## Environment Variables
+
+Following is the list of the all the environment variables that can be passed down to the geoserver docker image, you can check the defaul values for an image using `docker inspect [IMAGE_NAME]`
+| VAR NAME | DESCRIPTION | SAMPLE VALUE |
+|--------------|-----------|------------|
+| PATH | Used by geoserver internally to find all the libs | `/usr/local/sbin:/usr/local/bin:` |
+| CATALINA_HOME | CATALINA home path | `/opt/apache-tomcat-9.0.75` |
+| EXTRA_JAVA_OPTS | Used to pass params to the JAVA environment | `-Xms256m -Xmx1g` |
+| CORS_ENABLED | CORS enabled configuration | `false` |
+| CORS_ALLOWED_ORIGINS | CORS origins configuration | `*` |
+| CORS_ALLOWED_METHODS | CORS method configuration | `GET,POST` |
+| CORS_ALLOWED_HEADERS | CORS headers configuration | `*` |
+| DEBIAN_FRONTEND | Configures the Debian package manager frontend | `noninteractive`|
+| CATALINA_OPTS | Catalina options | `-Djava.awt.headless=true` |
+| GEOSERVER_VERSION | Geoserver version (used internally) | `2.24-SNAPSHOT`|
+| GEOSERVER_BUILD | Geosever build (used internally) | `1628` |
+| GEOSERVER_DATA_DIR | Geosever data directory location | `/opt/geoserver_data/` |
+| GEOSERVER_REQUIRE_FILE | Geoserver configuration used interally | `/opt/geoserver_data/global.xml` |
+| GEOSERVER_LIB_DIR | Sets the directory containing GeoServer's library files | `/opt/apache-tomcat-9.0.75/webapps/geoserver/WEB-INF/lib/` |
+| INSTALL_EXTENSIONS | Indicates whether additional GeoServer extensions should be installed | `false` |
+| WAR_ZIP_URL | Specifies the URL for a GeoServer Web Archive (WAR) file | |
+| STABLE_EXTENSIONS | Specifies stable GeoServer extensions | |
+| STABLE_PLUGIN_URL | Specifies the URL for downloading the latest stable GeoServer plugins | `https://build.geoserver.org/geoserver/2.24.x/ext-latest` |
+| COMMUNITY_EXTENSIONS | Specifies community-contributed GeoServer extensions | |
+| COMMUNITY_PLUGIN_URL | Specifies the URL for downloading the latest community-contributed GeoServer plugins | `https://build.geoserver.org/geoserver/2.24.x/community-latest` |
+| ADDITIONAL_LIBS_DIR | Sets the directory for additional libraries used by GeoServer | `/opt/additional_libs/` |
+| ADDITIONAL_FONTS_DIR | Sets the directory for additional fonts used by GeoServer | `/opt/additional_fonts/` |
+| SKIP_DEMO_DATA | Indicates whether to skip the installation of demo data provided by GeoServer | `false` |
+| ROOT_WEBAPP_REDIRECT | Indicates whether to issue a permanent redirect to the web interface | `false` |
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
Adding all the env vars in table format in README. The list was obtained using `docker inspect IMAGE_NAME`. 
Some of the values are duplicated with some examples above. 
Some points that can be further added are:
- Reference to docs for JAVA variables 
- Reference to dosc for CATALINA variables 
- Some variables should not be changed like `GEOSERVER_VERSION` so maybe mark them as `should not change`? (confused on this) 
- Add sample value for empty places
