### PR TITLE
Introduce health checks for GeoServer (and postgis db in demo)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ ENV ROOT_WEBAPP_REDIRECT=false
 ENV POSTGRES_JNDI_ENABLED=false
 ENV CONFIG_DIR=/opt/config
 ENV CONFIG_OVERRIDES_DIR=/opt/config_overrides
+ENV HEALTHCHECK_URL=http://localhost:8080/geoserver/web/wicket/resource/org.geoserver.web.GeoServerBasePage/img/logo.png
 
 EXPOSE 8080
 
@@ -126,3 +127,6 @@ RUN chmod +x /opt/*.sh
 ENTRYPOINT ["/opt/startup.sh"]
 
 WORKDIR /opt
+
+HEALTHCHECK --interval=1m --timeout=20s --retries=3 \
+  CMD curl --fail $HEALTHCHECK_URL || exit 1

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Following is the list of the all the environment variables that can be passed do
 | ADDITIONAL_FONTS_DIR | Sets the directory for additional fonts used by GeoServer | `/opt/additional_fonts/` |
 | SKIP_DEMO_DATA | Indicates whether to skip the installation of demo data provided by GeoServer | `false` |
 | ROOT_WEBAPP_REDIRECT | Indicates whether to issue a permanent redirect to the web interface | `false` |
+| HEALTHCHECK_URL | URL to the resource / endpoint used for `docker` health checks | `http://localhost:8080/geoserver/web/wicket/resource/org.geoserver.web.GeoServerBasePage/img/logo.png` |
 
 The following values cannot really be safely changed (as they are used to download extensions and community modules as the docker image first starts up).
 | VAR NAME | DESCRIPTION | SAMPLE VALUE |

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -23,6 +23,11 @@ services:
     volumes:
       - ./geoserver_data:/opt/geoserver_data/:Z
       - ./additional_libs:/opt/additional_libs:Z # by mounting this we can install libs from host on startup
+    healthcheck:
+      test: curl --fail "http://localhost:8080/geoserver/web/wicket/resource/org.geoserver.web.GeoServerBasePage/img/logo.png" || exit 1
+      interval: 1m
+      retries: 3
+      timeout: 20s
   postgis:
     image: postgis/postgis:16-3.4-alpine
     ports:

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -8,7 +8,7 @@ services:
         - CORS_ENABLED=true
         - CORS_ALLOWED_METHODS=GET,POST,PUT,HEAD,OPTIONS
     ports:
-      - 80:8080
+      - "80:8080"
     environment:
       - INSTALL_EXTENSIONS=true
       - STABLE_EXTENSIONS=wps,csw
@@ -32,3 +32,8 @@ services:
       POSTGRES_PASSWORD: geoserver
     volumes:
       - ./postgis/postgresql_data:/var/lib/postgresql/data:Z
+    healthcheck:
+      test: pg_isready -U geoserver -h localhost -t 5 || exit 1
+      interval: 10s
+      retries: 5
+      timeout: 10s


### PR DESCRIPTION
This PR introduces a configurable docker health check (see also here).
Currently, the logo of the landing page is used for check, however it can be configured using the HEALTHCHECK_URL environment variable.

In the demo docker compose file a corresponding block for the postgis database has been added.