### PR TITLE
chore: do not fail with known vulns

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           image-ref: 'geoserver-docker.osgeo.org/geoserver:${{ github.sha }}'
           format: 'table'
-          exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'


### PR DESCRIPTION
For the time being it should be fine to have the output of the github action (security scan) as a background info, but it should not be blocking in any way.