### PR TITLE
fix: use sarif format in trivy results

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run trivy
         uses: aquasecurity/trivy-action@master
         with:
-          format: 'table'
+          format: 'sarif'
           ignore-unfixed: true
           image-ref: 'geoserver-docker.osgeo.org/geoserver:${{ github.sha }}'
           output: 'trivy-results.sarif'


### PR DESCRIPTION
Fixes the output format of `trivy` workflow.