### PR TITLE
feat: add renovate bot

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices"
+    ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -14,3 +14,6 @@ jobs:
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          RENOVATE_AUTODISCOVER: true
+          RENOVATE_AUTODISCOVER_FILTER: "/geoserver/docker/"

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,16 @@
+name: renovate
+on:
+  schedule:
+    - cron: '0 5 * * *' # every day at 5
+  workflow_dispatch:
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4.1.1
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v40.0.2
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
This introduces a [renovate bot](https://github.com/renovatebot/renovate) configuration and enables a scheduled github action that checks for dependency updates on all levels (github actions, docker base images). Renovate will then create pull requests whenever it detects new versions. Especially, this leads to the use of explicit docker image digests in the Dockerfile. This is an essential preparation for the suggestions made in [GEOS-11231](https://osgeo-org.atlassian.net/browse/GEOS-11231). 

We tested this in a forked repo. Here is an example output: https://github.com/buehner/docker-geoserver-official/pull/5

Note: This does not produce auto-merges, but instead provides a helpful overview on base images that can be updated.

However: To get this running, a github secret named `RENOVATE_TOKEN` is required. The content of this secret is a personal github access token (classic) with the following scopes: `repo` (all) and `workflow`. As we do not have sufficient rights to create such a secret/token, it would be great if one of you could prepare this and let us know here @jodygarnett @aaime 

Regarding [GEOS-11231](https://osgeo-org.atlassian.net/browse/GEOS-11231) we could then think about triggering a jenkins job to recreate the geoserver docker images based on the updated base images. The docker tags would not change, but by using explicit digests it would still be possible to use older images.

Pseudo example:

```bash
curl https://build.geoserver.org/job/JOB_NAME/buildWithParameters \
--user USER:TOKEN \
--data id=123 --data verbosity=high
```