### PR TITLE
fix: do not run as custom user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,15 +141,7 @@ RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
 
 # GeoServer user => restrict access to $CATALINA_HOME and GeoServer directories
 # See also CIS Docker benchmark and docker best practices
-RUN chmod +x /opt/*.sh \
-    && groupadd geoserver  \
-    && useradd --no-log-init -u 2000 -r -g geoserver geoserver \
-    && chown -R geoserver:geoserver $CATALINA_HOME \
-    && chmod g-w,o-rwx $CATALINA_HOME \
-    && chown -R geoserver:geoserver $GEOSERVER_DATA_DIR \
-    && chown -R geoserver:geoserver $GEOSERVER_LIB_DIR
-
-USER geoserver
+RUN chmod +x /opt/*.sh
 
 ENTRYPOINT ["/opt/startup.sh"]
 


### PR DESCRIPTION
The problem described in https://github.com/geoserver/docker/pull/39#issuecomment-1954273220 is a result of the custom `geoserver` user that runs the tomcat in the docker container (see changset of this PR). This user is currently not allowed to create the additional libs dir, which is required for their installation.

We also found out that this custom user may lead to problems in setups with docker mounts, which could be solved by changing file/directory ownerships on the host system to `2000:2000` (which is/was the geoserver uid in the container).

To be able to include the recent changes in this project for the current/next geoserver release, we propose to revert the introduction of the custom `geoserver` user for the time being.

**Note: Herewith, the user running the tomcat process does not change compared to the currently available versions/images.**

In a follow-up pull request we would probably introduce this custom user again for security reasons. But we'd also like to ensure that this change will not break anything and allow usage in all environments (for example docker compose in different operating systems)

Please review for the current release @petersmythe 