### PR TITLE
Set admin credentials with environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,9 +142,9 @@ RUN find / -perm /6000 -type f -exec chmod a-s {} \; || true
 
 # GeoServer user => restrict access to $CATALINA_HOME and GeoServer directories
 # See also CIS Docker benchmark and docker best practices
-RUN chmod +x /opt/*.sh
+RUN chmod +x /opt/*.sh && sed -i 's/\r$//' /opt/startup.sh
 
-ENTRYPOINT ["/opt/startup.sh"]
+ENTRYPOINT ["bash", "/opt/startup.sh"]
 
 WORKDIR /opt
 

--- a/startup.sh
+++ b/startup.sh
@@ -142,4 +142,8 @@ if [ ! "${ENABLE_DEFAULT_SHUTDOWN}" = "true" ]; then
   REPLACEMENT=
 fi
 
+if [ -n "$GEOSERVER_ADMIN_PASSWORD" ] && [ -n "$GEOSERVER_ADMIN_USER" ]; then
+    /bin/sh /opt/update_credentials.sh
+fi
+
 exec $CATALINA_HOME/bin/catalina.sh run -Dorg.apache.catalina.connector.RECYCLE_FACADES=true

--- a/update_credentials.sh
+++ b/update_credentials.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+# Credits to https://github.com/meggsimum/geoserver-docker/ and https://github.com/kartoza/docker-geoserver
+
+echo "Updating GeoServer Credentials ..."
+
+if [ ${DEBUG} ]; then
+  set -e
+  set -x
+fi;
+
+# copy over default security folder to data dir (if not existing)
+if [ ! -d "${GEOSERVER_DATA_DIR}security" ]; then
+  cp -r ${CATALINA_HOME}"/webapps/"$APP_PATH_PREFIX"geoserver/data/security" ${GEOSERVER_DATA_DIR}
+fi
+
+GEOSERVER_ADMIN_USER=${GEOSERVER_ADMIN_USER:-admin}
+GEOSERVER_ADMIN_PASSWORD=${GEOSERVER_ADMIN_PASSWORD:-geoserver}
+
+# templates to use as base for replacement
+USERS_XML_ORIG=${CATALINA_HOME}"/webapps/"$APP_PATH_PREFIX"geoserver/data/security/usergroup/default/users.xml"
+echo "USING USERS XML ORIGINAL:" $USERS_XML_ORIG
+ROLES_XML_ORIG=${CATALINA_HOME}"/webapps/"$APP_PATH_PREFIX"geoserver/data/security/role/default/roles.xml"
+echo "USING ROLES XML ORIGINAL:" $ROLES_XML_ORIG
+
+# final users.xml file GeoServer data dir
+USERS_XML=${USERS_XML:-${GEOSERVER_DATA_DIR}security/usergroup/default/users.xml}
+echo "SETTING USERS XML:" $USERS_XML
+# final roles.xml file GeoServer data dir
+ROLES_XML=${ROLES_XML:-${GEOSERVER_DATA_DIR}security/role/default/roles.xml}
+echo "SETTING ROLES XML:" . $ROLES_XML
+
+CLASSPATH=$CATALINA_HOME/webapps/$APP_PATH_PREFIX"geoserver/WEB-INF/lib/"
+
+# tmp files
+TMP_USERS=/tmp/users.xml
+TMP_ROLES=/tmp/roles.xml
+
+make_hash(){
+  NEW_PASSWORD=$1
+  (echo "digest1:" && java -classpath $(find $CLASSPATH -regex ".*jasypt-[0-9]\.[0-9]\.[0-9].*jar") org.jasypt.intf.cli.JasyptStringDigestCLI digest.sh algorithm=SHA-256 saltSizeBytes=16 iterations=100000 input="$NEW_PASSWORD" verbose=0) | tr -d '\n'
+}
+
+# create PW hash for given password
+PWD_HASH=$(make_hash $GEOSERVER_ADMIN_PASSWORD)
+
+# USERS.XML SETUP
+# <user enabled="true" name="admin" password="digest1:D9miJH/hVgfxZJscMafEtbtliG0ROxhLfsznyWfG38X2pda2JOSV4POi55PQI4tw"/>
+cat $USERS_XML_ORIG | sed -e "s/ name=\".*\" / name=\"${GEOSERVER_ADMIN_USER}\" /" | sed -e "s|password=\".*\"/|password=\"${PWD_HASH}\"\/|" > $TMP_USERS
+if [ $? -eq 0 ]
+then
+    mv $TMP_USERS $USERS_XML
+    echo "Successfully replaced $USERS_XML"
+else
+    echo "CAUTION: Abort update_credentials.sh due to error while creating users.xml. File at $USERS_XML keeps untouched"
+    exit
+fi
+
+# ROLES.XML SETUP
+# <userRoles username="admin">
+cat $ROLES_XML_ORIG | sed -e "s/ username=\".*\"/ username=\"${GEOSERVER_ADMIN_USER}\"/" > $TMP_ROLES
+if [ $? -eq 0 ]
+then
+    mv $TMP_ROLES $ROLES_XML
+    echo "Successfully replaced $ROLES_XML"
+else
+    echo "CAUTION: Abort update_credentials.sh due to error while creating roles.xml. File at $ROLES_XML keeps untouched"
+    exit
+fi
+
+echo "... DONE updating GeoServer Credentials ..."


### PR DESCRIPTION
This project lacked the option of specifying the username and password of the admin user via environment variables. With this PR it's possible to set the admin credentials like so:

```sh
podman run -d -p 8081:8080 -e GEOSERVER_ADMIN_USER=admin -e GEOSERVER_ADMIN_PASSWORD=geoserver <image>
```
The changes are heavily influenced by preliminary work of [meggsimum](https://github.com/meggsimum/geoserver-docker/) and [kartoza](https://github.com/kartoza/docker-geoserver).