### PR TITLE
feat: ignore pg data when using compose example

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 build/
+postgis/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.iml
 *.idea
-
+postgis/


### PR DESCRIPTION
Ignore a potential postgis subdir that may be created when using the docker compose example. Without this change, you could end up with permission problems when using docker for the project.