### PR TITLE
Build and release Geoserver multi-platform for ARM64 and AMD64.

### DIFF
--- a/build/release.sh
+++ b/build/release.sh
@@ -85,7 +85,7 @@ if [[ $1 == *build* ]]; then
         -t $TAG .
     fi
   else
-    echo "docker build ---platform linux/amd64,linux/arm64 -build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
+    echo "docker build --platform linux/amd64,linux/arm64 --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
     docker build \
       --platform linux/amd64,linux/arm64 \
       --build-arg GS_VERSION=$VERSION \

--- a/build/release.sh
+++ b/build/release.sh
@@ -49,6 +49,9 @@ else
   fi
 fi
 
+# Prerequisite for Multi-Arch via QEMU:
+docker run --privileged --rm tonistiigi/binfmt --install all
+
 echo "Release from branch $BRANCH GeoServer $VERSION as $TAG"
 
 # Go up one level to the Dockerfile
@@ -60,9 +63,10 @@ if [[ $1 == *build* ]]; then
     echo "  nightly build from https://build.geoserver.org/geoserver/$BRANCH"
     echo
     if [[ "$BRANCH" == "main" ]]; then
-      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
+      echo "docker build --platform linux/amd64,linux/arm64 --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
       # todo: --no-cache-filter download,install
       docker build \
+        --platform linux/amd64,linux/arm64 \
         --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip \
         --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/main/ext-latest \
         --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest \
@@ -70,8 +74,9 @@ if [[ $1 == *build* ]]; then
         --build-arg GS_BUILD=$BUILD \
         -t $TAG .
     else
-      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
+      echo "docker build --platform linux/amd64,linux/arm64 --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
       docker build \
+        --platform linux/amd64,linux/arm64 \
         --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip \
         --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/ext-latest \
         --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/community-latest \
@@ -80,8 +85,9 @@ if [[ $1 == *build* ]]; then
         -t $TAG .
     fi
   else
-    echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
+    echo "docker build ---platform linux/amd64,linux/arm64 -build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
     docker build \
+      --platform linux/amd64,linux/arm64 \
       --build-arg GS_VERSION=$VERSION \
       --build-arg GS_BUILD=$BUILD \
       -t $TAG .


### PR DESCRIPTION
Currently, the docker images at https://docker.osgeo.org are only compatible with AMD64 platform. Basically, they run on Intel and AMD, not on ARM. 

ARM CPUs are winning in popularity, and hosters like Hetzner offer them as root-servers, too.

This pull request will change the release.sh to build and push images for both platforms in parallel. After applying this PR, the release-Script will fail unless the docker-daemon has been set up for multi-platform build, as described here 
https://docs.docker.com/build/building/multi-platform/#qemu

tl/tr: 
 * Add to /etc/docker/daemon.json `{"features": {"containerd-snapshotter": true }}` and restart docker, e.g. `systemctl restart docker`
* Create a custom builder:
 `docker buildx create --name container-builder --driver docker-container --use --bootstrap`

After that, running build/release.sh should build and push images for both platforms. I cannot test the push, since I have not Nexus Repository to test! Building does not take much longer.

Whoever is releasing new geoserver docker images regularly, will need a multi-platform docker setup.

NB: With our docker-repository provider quay.io, we experienced, that the first push to a repository had to be multi-platform, for the repository to support multi-platform! I think we simply have to try with Nexus here.

Of course I am happy to test on ARM as soon and images are pushed.