### PR TITLE
chore: use JDK 17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.95-jdk11-temurin-jammy@sha256:8e90c21d9feb8b6d03706200de17670d0e202aa623a78958c1971a8fd4c58613
+FROM tomcat:9.0.95-jdk17-temurin-jammy@sha256:4ac5245eb0de6361774a8e3b2cd57d368bdec614028d945e51530072a791b84c
 LABEL vendor="osgeo.org"
 
 # Build arguments


### PR DESCRIPTION
OpenJDK Java 11 reaches end-of-life October 2024. So this updates from JDK11 to JDK17.

According to https://github.com/geoserver/geoserver/wiki/Release-Schedule#2024 GeoServer 2.26.0 will be the first version supporting this "officially"

@jodygarnett maybe it makes sense to merge this before building 2.26.0 ?