### PR TITLE
Allow running tomcat as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ ENV HEALTHCHECK_URL=''
 ENV INSTALL_EXTENSIONS=false
 ENV POSTGRES_JNDI_ENABLED=false
 ENV ROOT_WEBAPP_REDIRECT=false
+ENV RUN_UNPRIVILEGED=false
+ENV RUN_WITH_USER_UID=
+ENV RUN_WITH_USER_GID=
+ENV CHANGE_OWNERSHIP_ON_FOLDERS="/opt $GEOSERVER_DATA_DIR"
 ENV SKIP_DEMO_DATA=false
 ENV STABLE_EXTENSIONS=''
 ENV STABLE_PLUGIN_URL=$STABLE_PLUGIN_URL
@@ -62,7 +66,7 @@ WORKDIR /tmp
 RUN set -eux \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get update \
-    && apt-get install -y --no-install-recommends openssl unzip curl locales gettext \
+    && apt-get install -y --no-install-recommends openssl unzip curl locales gettext gosu \
     && apt-get clean \
     && rm -rf /var/cache/apt/* \
     && rm -rf /var/lib/apt/lists/* \
@@ -115,6 +119,14 @@ RUN apt purge -y  \
 # See also CIS Docker benchmark and docker best practices
 
 RUN chmod +x /opt/*.sh && sed -i 's/\r$//' /opt/startup.sh
+
+# # Create a non-privileged tomcat user
+# ARG USER_GID=999
+# ARG USER_UID=999
+# RUN addgroup --gid ${USER_GID} tomcat && \
+#     adduser --system  -u ${USER_UID} --gid ${USER_GID} --no-create-home tomcat && \
+#     chown -R tomcat:tomcat /opt && \
+#     chown tomcat:tomcat $GEOSERVER_DATA_DIR
 
 ENTRYPOINT ["bash", "/opt/startup.sh"]
 

--- a/startup.sh
+++ b/startup.sh
@@ -167,4 +167,23 @@ if [ -n "$GEOSERVER_ADMIN_PASSWORD" ] && [ -n "$GEOSERVER_ADMIN_USER" ]; then
     /bin/sh /opt/update_credentials.sh
 fi
 
-exec $CATALINA_HOME/bin/catalina.sh run -Dorg.apache.catalina.connector.RECYCLE_FACADES=true
+# Run as non-privileged user
+if [ "${RUN_UNPRIVILEGED}" = "true" ]; then
+  echo "The server will be run as non-privileged user 'tomcat'"
+
+  RUN_WITH_USER_UID=${RUN_WITH_USER_UID:=999}
+  RUN_WITH_USER_GID=${RUN_WITH_USER_GID:=${RUN_WITH_USER_UID} }
+
+  echo "creating user tomcat (${RUN_WITH_USER_UID}:${RUN_WITH_USER_GID})"
+  addgroup --gid ${RUN_WITH_USER_GID} tomcat && \
+    adduser --system -u ${RUN_WITH_USER_UID} --gid ${RUN_WITH_USER_GID} \
+            --no-create-home tomcat 
+
+  if [ -n "$CHANGE_OWNERSHIP_ON_FOLDERS" ]; then
+    echo "Changing ownership accordingly ($CHANGE_OWNERSHIP_ON_FOLDERS)"
+    chown -R tomcat:tomcat $CHANGE_OWNERSHIP_ON_FOLDERS
+  fi
+
+fi
+
+exec gosu tomcat $CATALINA_HOME/bin/catalina.sh run -Dorg.apache.catalina.connector.RECYCLE_FACADES=true

--- a/startup.sh
+++ b/startup.sh
@@ -168,7 +168,8 @@ if [ -n "$GEOSERVER_ADMIN_PASSWORD" ] && [ -n "$GEOSERVER_ADMIN_USER" ]; then
 fi
 
 # Run as non-privileged user
-if [ "${RUN_UNPRIVILEGED}" = "true" ]; then
+if [ "${RUN_UNPRIVILEGED}" = "true" ]
+then
   echo "The server will be run as non-privileged user 'tomcat'"
 
   RUN_WITH_USER_UID=${RUN_WITH_USER_UID:=999}
@@ -183,7 +184,9 @@ if [ "${RUN_UNPRIVILEGED}" = "true" ]; then
     echo "Changing ownership accordingly ($CHANGE_OWNERSHIP_ON_FOLDERS)"
     chown -R tomcat:tomcat $CHANGE_OWNERSHIP_ON_FOLDERS
   fi
-
+  
+  exec gosu tomcat $CATALINA_HOME/bin/catalina.sh run -Dorg.apache.catalina.connector.RECYCLE_FACADES=true
+else
+  exec $CATALINA_HOME/bin/catalina.sh run -Dorg.apache.catalina.connector.RECYCLE_FACADES=true
 fi
 
-exec gosu tomcat $CATALINA_HOME/bin/catalina.sh run -Dorg.apache.catalina.connector.RECYCLE_FACADES=true


### PR DESCRIPTION
It is a good practice to allow running a container as unprivileged user. 

To preserve backward compatibility and provide flexibility, this feature is added at the entrypoint level and is set using environment variables.
- RUN_UNPRIVILEGED=true activates the unprivileged mode with default uid:gid as 999:999
- RUN_WITH_USER_UID allows to set the uid used for tomcat user
- RUN_WITH_USER_UID allows to set the gid used for tomcat group
- CHANGE_OWNERSHIP_ON_FOLDERS accepts a space-separated list of folder on which a chmod will be run, changing (recursively) the ownership for the tomcat user.