### PR TITLE
feat: allow EXTRA_JAVA_OPTS to be configured at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,8 @@ ENV WEBAPP_CONTEXT=geoserver
 #    --add-opens=java.desktop/sun.java2d.pipe=ALL-UNNAMED
 
 # see https://docs.geoserver.org/stable/en/user/production/container.html
-ENV CATALINA_OPTS="\$EXTRA_JAVA_OPTS \
+# `EXTRA_JAVA_OPTS` will be prepended during runtime by startup.sh
+ENV CATALINA_OPTS=" \
     --add-exports=java.desktop/sun.awt.image=ALL-UNNAMED \
     --add-opens=java.base/java.lang=ALL-UNNAMED \
     --add-opens=java.base/java.util=ALL-UNNAMED \

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ The ``startup.sh`` script allows some customization on startup:
   * ``CORS_ALLOWED_HEADERS`` (default ``Origin,Accept,X-Requested-With,Content-Type,Access-Control-Request-Method,Access-Control-Request-Headers``)
   * ``CORS_ALLOW_CREDENTIALS`` (default ``false``) **Setting this to ``true`` will only have the desired effect if ``CORS_ALLOWED_ORIGINS`` defines explicit origins (not ``*``)**
 * ``PROXY_BASE_URL`` to the base URL of the GeoServer web app if GeoServer is behind a proxy. Example: ``https://example.com/geoserver``.
+* ``EXTRA_JAVA_OPTS`` to pass params to the JAVA environment.
 
 The CORS variables customize tomcat's `web.xml` file. If you need more customization,
 you can provide your own customized `web.xml` file to tomcat by mounting it into the container

--- a/startup.sh
+++ b/startup.sh
@@ -153,6 +153,9 @@ if [ "${HTTPS_ENABLED}" = "true" ]; then
   envsubst < "${CONFIG_DIR}"/server-https.xml > "${CATALINA_HOME}/conf/server.xml"
 fi
 
+# Add configurable runtime options via EXTRA_JAVA_OPTS
+export CATALINA_OPTS="${EXTRA_JAVA_OPTS} ${CATALINA_OPTS}"
+
 # start the tomcat
 # CIS - Tomcat Benchmark recommendations:
 # * Turn off session facade recycling


### PR DESCRIPTION
`EXTRA_JAVA_OPTS` is currently non-configurable and is added to `CATALINA_OPTS` at build time.

Users may want to configure the JVM heap values as well as some [application properties](https://docs.geoserver.org/main/en/user/configuration/properties/index.html#application-properties) at runtime, outside of the build process.

This change allows commands like the following to work:

```bash
docker run -p 8080:8080 -e "EXTRA_JAVA_OPTS=-Xmx2g" geoserver
```

This is picked up by Catalina when starting

![image](https://github.com/user-attachments/assets/d8692c5a-a6cc-47f4-9bec-ed10d43a50fb)

and is also reflected in the GeoServer web console

![image](https://github.com/user-attachments/assets/8d32afe5-cf2f-4762-b2b8-51ca75333d60)
