### PR TITLE
fixed community extension URL

### DIFF
--- a/install-extensions.sh
+++ b/install-extensions.sh
@@ -29,7 +29,7 @@ if [ "$INSTALL_EXTENSIONS" = "true" ]; then
     download_extension ${URL} ${EXTENSION}
   done
   for EXTENSION in $(echo "${COMMUNITY_EXTENSIONS}" | tr ',' ' '); do
-    URL="${COMMUNITY_PLUGIN_URL}/geoserver-${GEOSERVER_VERSION}-${EXTENSION}-plugin.zip"
+    URL="${COMMUNITY_PLUGIN_URL}/geoserver-$(echo ${GEOSERVER_VERSION} | cut -d'.' -f1,2)-SNAPSHOT-${EXTENSION}-plugin.zip"
     download_extension ${URL} ${EXTENSION}
   done
   echo "Finished download of extensions"


### PR DESCRIPTION
This updates the community extension download URL as the community extensions have a different naming convention from the stable extensions.