### PR TITLE
Documented that context.xml isn't used anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,15 @@ To enable a PostgreSQL JNDI resource, provide the following environment variable
 
 In geoserver, you can then reference this JNDI resource using the name `java:comp/env/jdbc/postgres` (if using default).
 
+Note: previously you could tweak the JNDI settings in a custom `context.xml` (see below), but its contents are now included in `server.xml`.
+
+
 ## How to use custom (tomcat) configuration files
 
 This image provides default (tomcat) configurations that are located in the `./config/` subdir.
 
-* `context.xml` (see/compare JNDI feature from above)
 * `server.xml` (security hardened version by default)
+* ~context.xml~ (now included into `server.xml`, previously used for JNDI settings)
 
 In case you want to fully overwrite such a config file, you can do so by mounting it to the `/opt/config_overrides/` directory of a container.
 The `startup.sh` script will then copy (and overwrite) these files to the catalina conf directory before starting tomcat.


### PR DESCRIPTION
Commit https://github.com/geoserver/docker/commit/ce561ff777f64756e4f0ed4692e2782005b0e11b removed `context.xml` and moved it into `server.xml`.
Previously, I used `context.xml` to configure JNDI for my geoservers, taking advantage of some local conventions to limit the amount of environment variables.

After updating from 2.25.x to 2.26.1 today, it took me some time to discover why my JNDI wasn't being found anymore :-) Cause: my `context.xml` wasn't used anymore.

So I've documented it.