### PR TITLE
GEOS-11684: base image does not include GDAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The ``startup.sh`` script allows some customization on startup:
 
 * ``INSTALL_EXTENSIONS`` to ``true`` to download and install extensions
 * ``STABLE_EXTENSIONS`` list of extensions to download and install
+* ``INSTALL_GDAL`` to ``true`` to download and install GDAL (required for GDAL/OGR extensions)
 * ``CORS_ENABLED`` to ``true`` to enable CORS support. The following environment variables can be used to customize the CORS configuration.
   * ``CORS_ALLOWED_ORIGINS`` (default ``*``)
   * ``CORS_ALLOWED_METHODS`` (default ``GET,POST,PUT,DELETE,HEAD,OPTIONS``)
@@ -241,6 +242,7 @@ Following is the list of the all the environment variables that can be passed do
 | SET_GEOSERVER_REQUIRE_FILE | If set to true, the GEOSERVER_REQUIRE_FILE will be automatically set to `$GEOSERVER_DATA_DIR/global.xml` on startup. If GEOSERVER_REQUIRE_FILE is set it will take precedence. | `true` |
 | INSTALL_EXTENSIONS | Indicates whether additional GeoServer extensions should be installed | `false` |
 | WAR_ZIP_URL | Specifies the URL for a GeoServer Web Archive (WAR) file | |
+| INSTALL_GDAL | Indicates if GDAL should be installed, GDAL is required for extensions that use GDAL/OGR, it is not installed by default | `false` |
 | STABLE_EXTENSIONS | Specifies stable GeoServer extensions | |
 | STABLE_PLUGIN_URL | Specifies the URL for downloading the latest stable GeoServer plugins | `https://build.geoserver.org/geoserver/2.26.x/ext-latest` |
 | COMMUNITY_EXTENSIONS | Specifies community-contributed GeoServer extensions | |

--- a/startup.sh
+++ b/startup.sh
@@ -80,6 +80,23 @@ else
   fi
 fi
 
+## install GDAL if requested, before extensions which may require it
+if [ "${INSTALL_GDAL}" = "true" ]; then
+  echo "Checking GDAL install status..."
+  STATUS_GDAL="$(dpkg-query -W --showformat='${db:Status-Status}' gdal-bin 2>&1)"
+  echo "... $STATUS_GDAL"
+  if [ ! $? = 0 ] || [ ! "$STATUS_GDAL" = "installed" ]; then
+    echo "Installing GDAL"
+    ## default permissions on temp do not allow writing, enable it
+    chmod 777 /tmp
+    apt-get update
+    ## this includes recommended packages, like proj-bin
+    apt-get install -y gdal-bin
+    ## restore default permissions
+    chmod 755 /tmp
+  fi
+fi
+
 ## install GeoServer extensions before starting the tomcat
 /opt/install-extensions.sh
 


### PR DESCRIPTION
Further notes/discussion: https://osgeo-org.atlassian.net/browse/GEOS-11684

Since the base image was changed from Ubuntu to Tomcat it no longer includes GDAL, which is required for GDAL/OGR extensions.

The rationale behind this PR is to enable installing GDAL without affecting (i.e. increasing the size of) the initial image.

This PR:
 - adds/documents an `INSTALL_GDAL` environment variable 
 - prior to installing extensions in `startup.sh`:
     - check if INSTALL_GDAL=true
     - check if `gdal-bin` is already installed
     - modify permissions on `/tmp` to enable apt-get update (initially the directory is not writable, which will cause update to fail)
     - update and install gdal-bin, including recommended packages (notably proj)
     - restore `/tmp` permissions

Happy to discuss if an alternative approach might be more appropriate.