### PR TITLE
Add GDAL with Java Bindings Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This Dockerfile can be used to create images for all geoserver versions since 2.
 
 * Based on the official [`tomcat` docker image](https://hub.docker.com/_/tomcat), in particular:
   * Tomcat 9
-  * JDK11 (eclipse temurin)
+  * JDK17 (eclipse temurin)
   * Ubuntu Jammy (22.04 LTS)
 * GeoServer installation is configurable and supports
   * Dynamic installation of extensions
@@ -13,6 +13,7 @@ This Dockerfile can be used to create images for all geoserver versions since 2.
   * Additional libraries
   * PostgreSQL JNDI
   * HTTPS
+  * GDAL with Java Bindings
 
 This README.md file covers use of official docker image, additional [build](BUILD.md) and [release](RELEASE.md) instructions are available.
 

--- a/build/release.sh
+++ b/build/release.sh
@@ -63,7 +63,7 @@ if [[ $1 == *build* ]]; then
     echo "  nightly build from https://build.geoserver.org/geoserver/$BRANCH"
     echo
     if [[ "$BRANCH" == "main" ]]; then
-      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
+      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD --build-arg BUILD_GDAL=true -t $TAG ."
       # todo: --no-cache-filter download,install
       docker build \
         --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip \
@@ -71,22 +71,25 @@ if [[ $1 == *build* ]]; then
         --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest \
         --build-arg GS_VERSION=$VERSION \
         --build-arg GS_BUILD=$BUILD \
+        --build-arg BUILD_GDAL=true \
         -t $TAG .
     else
-      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
+      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD --build-arg BUILD_GDAL=true -t $TAG ."
       docker build \
         --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip \
         --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/ext-latest \
         --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/community-latest \
         --build-arg GS_VERSION=$VERSION \
         --build-arg GS_BUILD=$BUILD \
+        --build-arg BUILD_GDAL=true \
         -t $TAG .
     fi
   else
-    echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD -t $TAG ."
+    echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD --build-arg BUILD_GDAL=true -t $TAG ."
     docker build \
       --build-arg GS_VERSION=$VERSION \
       --build-arg GS_BUILD=$BUILD \
+      --build-arg BUILD_GDAL=true \
       -t $TAG .
   fi
 fi

--- a/build/release.sh
+++ b/build/release.sh
@@ -13,6 +13,43 @@ function usage() {
   echo " build : Build number (optional)"
 }
 
+function build_geoserver_image() {
+    local VERSION=$1
+    local BUILD=$2
+    local BUILD_GDAL=$3
+    local TAG=$4
+    local BRANCH=$5
+
+    if [ -n "$VERSION" ] && [ -n "$BUILD" ] && [ -n "$BUILD_GDAL" ] && [ -n "$TAG" ]; then
+      if [ -n "$BRANCH" ]; then
+        # all needed vars are set
+
+        (set -x # echo docker build command
+        docker build \
+            --build-arg WAR_ZIP_URL="https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip" \
+            --build-arg STABLE_PLUGIN_URL="https://build.geoserver.org/geoserver/$BRANCH/ext-latest" \
+            --build-arg COMMUNITY_PLUGIN_URL="https://build.geoserver.org/geoserver/$BRANCH/community-latest" \
+            --build-arg GS_VERSION="$VERSION" \
+            --build-arg GS_BUILD="$BUILD" \
+            --build-arg BUILD_GDAL="$BUILD_GDAL" \
+            -t "$TAG" .)
+      elif [ -z "$BRANCH" ]; then
+        # BRANCH is not set
+
+        (set -x # echo docker build command
+        docker build \
+          --build-arg GS_VERSION=$VERSION \
+          --build-arg GS_BUILD=$BUILD \
+          --build-arg BUILD_GDAL=$BUILD_GDAL \
+          -t $TAG .)
+      fi
+
+    else
+      echo "Missing required parameters"
+      exit 1
+    fi
+}
+
 if [ -z $1 ] || [ -z $2 ] || [[ $1 != "build" && $1 != "publish" && $1 != "buildandpublish" ]]; then
   usage
   exit
@@ -26,26 +63,36 @@ else
   BUILD=$3
 fi
 
+BASE=geoserver-docker.osgeo.org/geoserver
+GDAL_SUFFIX=gdal
+
+echo "Building GeoServer Docker Image for version $VERSION"
+
 if [[ "$VERSION" == *"-M"* ]]; then
     # release candidate branch release
     BRANCH="${VERSION}"
-    TAG=geoserver-docker.osgeo.org/geoserver:$BRANCH
+    TAG=$BASE:$BRANCH
+    GDAL_TAG=$TAG-$GDAL_SUFFIX
 elif [[ "$VERSION" == *"-RC"* ]]; then
     # release candidate branch release
     BRANCH="${VERSION}"
-    TAG=geoserver-docker.osgeo.org/geoserver:$BRANCH
+    TAG=$BASE:$BRANCH
+    GDAL_TAG=$TAG-$GDAL_SUFFIX
 elif [[ "${VERSION:0:4}" == "$MAIN" ]]; then
   # main branch snapshot release
   BRANCH=main
-  TAG=geoserver-docker.osgeo.org/geoserver:$MAIN.x
+  TAG=$BASE:$MAIN.x
+  GDAL_TAG=$TAG-$GDAL_SUFFIX
 else
   if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
   # stable or maintenance branch snapshot release
   BRANCH="${VERSION:0:4}.x"
-  TAG=geoserver-docker.osgeo.org/geoserver:$BRANCH
+  TAG=$BASE:$BRANCH
+  GDAL_TAG=$TAG-$GDAL_SUFFIX
   else
   BRANCH="${VERSION:0:4}.x"
-  TAG=geoserver-docker.osgeo.org/geoserver:$VERSION
+  TAG=$BASE:$VERSION
+  GDAL_TAG=$TAG-$GDAL_SUFFIX
   fi
 fi
 
@@ -53,6 +100,7 @@ fi
 # docker run --privileged --rm tonistiigi/binfmt --install all
 
 echo "Release from branch $BRANCH GeoServer $VERSION as $TAG"
+echo "Release from branch $BRANCH GeoServer $VERSION (with GDAL) as $GDAL_TAG"
 
 # Go up one level to the Dockerfile
 cd ".."
@@ -62,41 +110,19 @@ if [[ $1 == *build* ]]; then
   if [[ "$VERSION" == *"-SNAPSHOT"* ]]; then
     echo "  nightly build from https://build.geoserver.org/geoserver/$BRANCH"
     echo
-    if [[ "$BRANCH" == "main" ]]; then
-      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD --build-arg BUILD_GDAL=true -t $TAG ."
-      # todo: --no-cache-filter download,install
-      docker build \
-        --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/main/geoserver-main-latest-war.zip \
-        --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/main/ext-latest \
-        --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/main/community-latest \
-        --build-arg GS_VERSION=$VERSION \
-        --build-arg GS_BUILD=$BUILD \
-        --build-arg BUILD_GDAL=true \
-        -t $TAG .
-    else
-      echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD --build-arg BUILD_GDAL=true -t $TAG ."
-      docker build \
-        --build-arg WAR_ZIP_URL=https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip \
-        --build-arg STABLE_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/ext-latest \
-        --build-arg COMMUNITY_PLUGIN_URL=https://build.geoserver.org/geoserver/$BRANCH/community-latest \
-        --build-arg GS_VERSION=$VERSION \
-        --build-arg GS_BUILD=$BUILD \
-        --build-arg BUILD_GDAL=true \
-        -t $TAG .
-    fi
+    build_geoserver_image $VERSION $BUILD "false" $TAG $BRANCH     # without gdal
+    build_geoserver_image $VERSION $BUILD "true" $GDAL_TAG $BRANCH # with gdal
   else
-    echo "docker build --build-arg GS_VERSION=$VERSION --build-arg GS_BUILD=$BUILD --build-arg BUILD_GDAL=true -t $TAG ."
-    docker build \
-      --build-arg GS_VERSION=$VERSION \
-      --build-arg GS_BUILD=$BUILD \
-      --build-arg BUILD_GDAL=true \
-      -t $TAG .
+    build_geoserver_image $VERSION $BUILD "false" $TAG   # without gdal
+    build_geoserver_image $VERSION $BUILD "true" $GDAL_TAG # with gdal
   fi
 fi
 
 if [[ $1 == *"publish"* ]]; then
-  echo "Publishing GeoServer Docker Image..."
+  echo "Publishing GeoServer Docker Images..."
   echo $DOCKERPASSWORD | docker login -u $DOCKERUSER --password-stdin geoserver-docker.osgeo.org
   echo "docker push $TAG"
   docker push $TAG
+  echo "docker push $GDAL_TAG"
+  docker push $GDAL_TAG
 fi


### PR DESCRIPTION
This pull request allows the integration of **GDAL** into the resulting GeoServer docker image. With a specific focus on **building the Java bindings**. Unlike the default Ubuntu package sources (like `gdal-bin`), which do not only provide an outdated version, but especially do not provide the Java bindings, this implementation ensures full compatibility with GDAL.

Related links:

* https://osgeo-org.atlassian.net/browse/GEOS-11684
* https://github.com/geoserver/docker/pull/135
* https://trac.osgeo.org/osgeolive/ticket/2288
* https://gdal.org/en/stable/api/java/index.html
* https://github.com/OSGeo/gdal/tree/master/docker/ubuntu-small (credits go here for the gdal build stage)

Usage: `docker build --build-arg BUILD_GDAL=true -t my-geoserver-image .`

Note: On average hardware, this takes ~10-15 mins, which is the reason to set the default for `BUILD_GDAL` to `false` (which results in the same docker image as before). There are two more new build arguments for optional use: `PROJ_VERSION=9.5.1` and `GDAL_VERSION=3.10.1`

The use of  `--build-arg BUILD_GDAL=true` leads to an increase of the resulting image of (only!) ~200MB as the installation of gdal requires some dependent packages to be installed, but the footprint is still "minimal" as we pick the build artifacts with `COPY --from=gdal_builder`.

I also updated the release script to build two variants of the image (one without and one with gdal (which has a `-gdal` suffix)).

## Comparison "Before vs After"

Use this to start your image with the gdal extension, which can be used to test the gdal functionality:
`docker run -it -p 8080:8080 --env INSTALL_EXTENSIONS=true --env STABLE_EXTENSIONS="gdal" my-geoserver-image`

### Before (without GDAL Java Bindings)

GeoServer-Log:
```
Native library load failed.
java.lang.UnsatisfiedLinkError: no gdalalljni in java.library.path: /usr/local/lib:/usr/local/tomcat/native-jni-lib:/usr/java/packages/lib:/usr/lib64:/lib64:/lib:/usr/lib
23-Jan-2025 11:40:07.783 WARNING [main] it.geosolutions.imageio.gdalframework.GDALUtilities.loadGDAL Failed to load the GDAL native libs. This is not a problem unless you need to use the GDAL plugins: they won't be enabled.
java.lang.UnsatisfiedLinkError: 'void org.gdal.gdal.gdalJNI.AllRegister()'
```

![no-bindings](https://github.com/user-attachments/assets/6b58ab99-053a-4c11-9213-bac19bda1438)


### After (with GDAL Java Bindings)

GeoServer-Log:
```
23-Jan-2025 11:38:24.013 INFO [main] it.geosolutions.imageio.gdalframework.GDALUtilities.loadGDAL GDAL Native Library loaded (version: 3.10.1)
```

![bindings](https://github.com/user-attachments/assets/6d4ba9f7-7682-4472-ab50-2099c13bd843)
