### PR TITLE
Allow passing Geoserver Admin credentials as Container secrets 

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,8 +253,8 @@ Following is the list of the all the environment variables that can be passed do
 | HEALTHCHECK_URL | URL to the resource / endpoint used for `docker` health checks | `http://localhost:8080/geoserver/web/wicket/resource/org.geoserver.web.GeoServerBasePage/img/logo.png` |
 | GEOSERVER_ADMIN_USER | Admin username |   |
 | GEOSERVER_ADMIN_PASSWORD | Admin password |  |
-| GEOSERVER_ADMIN_USER_FILE | Path to admin username file |  |
-| GEOSERVER_ADMIN_PASSWORD_FILE | Path to admin password file |  |
+| GEOSERVER_ADMIN_USER_FILE | Path to admin username file. Pass the username as a container secret (like `podman secret`) |  |
+| GEOSERVER_ADMIN_PASSWORD_FILE | Path to admin password file.  Pass the admin password as a container secret (like `podman secret`) |  |
 | RUN_UNPRIVILEGED | If set to `true`, runs as an unprivileged user `tomcat` instead of `root`. | `true` |
 | RUN_WITH_USER_UID | When running as unprivileged user, sets the uid of this user. Defaults to `999` | `999` |
 | RUN_WITH_USER_GID | When running as unprivileged user, sets the gid of this user. Defaults to the same as the uid | `999` |
@@ -273,10 +273,10 @@ The following values cannot really be safely changed (as they are used to downlo
 
 GeoServer supports file-based credentials for secure handling of admin credentials, particularly useful with Docker secrets or mounted files.
 
-| VAR NAME | DESCRIPTION | SAMPLE VALUE |
-|--------------|-----------|------------|
-| GEOSERVER_ADMIN_USER_FILE | Path to file containing admin username | `/run/secrets/geoserver_user` |
-| GEOSERVER_ADMIN_PASSWORD_FILE | Path to file containing admin password | `/run/secrets/geoserver_password` |
+| VAR NAME | DESCRIPTION | 
+|--------------|-----------|
+| GEOSERVER_ADMIN_USER_FILE | Path to file containing admin username |
+| GEOSERVER_ADMIN_PASSWORD_FILE | Path to file containing admin password |
 
 **Priority:** Direct environment variables (`GEOSERVER_ADMIN_USER`, `GEOSERVER_ADMIN_PASSWORD`) take precedence over file-based credentials when both are provided.
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Following is the list of the all the environment variables that can be passed do
 | HEALTHCHECK_URL | URL to the resource / endpoint used for `docker` health checks | `http://localhost:8080/geoserver/web/wicket/resource/org.geoserver.web.GeoServerBasePage/img/logo.png` |
 | GEOSERVER_ADMIN_USER | Admin username |   |
 | GEOSERVER_ADMIN_PASSWORD | Admin password |  |
+| GEOSERVER_ADMIN_USER_FILE | Path to admin username file |  |
+| GEOSERVER_ADMIN_PASSWORD_FILE | Path to admin password file |  |
 | RUN_UNPRIVILEGED | If set to `true`, runs as an unprivileged user `tomcat` instead of `root`. | `true` |
 | RUN_WITH_USER_UID | When running as unprivileged user, sets the uid of this user. Defaults to `999` | `999` |
 | RUN_WITH_USER_GID | When running as unprivileged user, sets the gid of this user. Defaults to the same as the uid | `999` |
@@ -266,6 +268,17 @@ The following values cannot really be safely changed (as they are used to downlo
 |--------------|-----------|------------|
 | GEOSERVER_VERSION | Geoserver version (used internally) | `2.27-SNAPSHOT`|
 | GEOSERVER_BUILD | Geoserver build (used internally) | `1628` |
+
+## Secrets
+
+GeoServer supports file-based credentials for secure handling of admin credentials, particularly useful with Docker secrets or mounted files.
+
+| VAR NAME | DESCRIPTION | SAMPLE VALUE |
+|--------------|-----------|------------|
+| GEOSERVER_ADMIN_USER_FILE | Path to file containing admin username | `/run/secrets/geoserver_user` |
+| GEOSERVER_ADMIN_PASSWORD_FILE | Path to file containing admin password | `/run/secrets/geoserver_password` |
+
+**Priority:** Direct environment variables (`GEOSERVER_ADMIN_USER`, `GEOSERVER_ADMIN_PASSWORD`) take precedence over file-based credentials when both are provided.
 
 ## Troubleshooting
 

--- a/startup.sh
+++ b/startup.sh
@@ -189,8 +189,49 @@ if [ ! "${ENABLE_DEFAULT_SHUTDOWN}" = "true" ]; then
   REPLACEMENT=
 fi
 
-if [ -n "$GEOSERVER_ADMIN_PASSWORD" ] && [ -n "$GEOSERVER_ADMIN_USER" ]; then
-    /bin/sh /opt/update_credentials.sh
+# Configure GeoServer admin credentials
+# Supports: GEOSERVER_ADMIN_USER/PASSWORD (env vars) or GEOSERVER_ADMIN_USER_FILE/PASSWORD_FILE (file paths)
+# Priority: Direct env vars take precedence over files
+
+ADMIN_USER=""
+ADMIN_PASSWORD=""
+
+# Resolve password from file or env var
+if [ -n "$GEOSERVER_ADMIN_PASSWORD_FILE" ] && [ -f "$GEOSERVER_ADMIN_PASSWORD_FILE" ]; then
+    if [ -n "$GEOSERVER_ADMIN_PASSWORD" ]; then
+        echo "Warning: Both GEOSERVER_ADMIN_PASSWORD and GEOSERVER_ADMIN_PASSWORD_FILE are set. Using GEOSERVER_ADMIN_PASSWORD."
+        ADMIN_PASSWORD="$GEOSERVER_ADMIN_PASSWORD"
+    else
+        ADMIN_PASSWORD=$(cat "$GEOSERVER_ADMIN_PASSWORD_FILE")
+        echo "Loaded GeoServer admin password from file: $GEOSERVER_ADMIN_PASSWORD_FILE"
+    fi
+elif [ -n "$GEOSERVER_ADMIN_PASSWORD_FILE" ]; then
+    echo "Error: GEOSERVER_ADMIN_PASSWORD_FILE is set to '$GEOSERVER_ADMIN_PASSWORD_FILE' but file does not exist or is not readable."
+    exit 1
+elif [ -n "$GEOSERVER_ADMIN_PASSWORD" ]; then
+    ADMIN_PASSWORD="$GEOSERVER_ADMIN_PASSWORD"
+fi
+
+# Resolve username from file or env var
+if [ -n "$GEOSERVER_ADMIN_USER_FILE" ] && [ -f "$GEOSERVER_ADMIN_USER_FILE" ]; then
+    if [ -n "$GEOSERVER_ADMIN_USER" ]; then
+        echo "Warning: Both GEOSERVER_ADMIN_USER and GEOSERVER_ADMIN_USER_FILE are set. Using GEOSERVER_ADMIN_USER."
+        ADMIN_USER="$GEOSERVER_ADMIN_USER"
+    else
+        ADMIN_USER=$(cat "$GEOSERVER_ADMIN_USER_FILE")
+        echo "Loaded GeoServer admin user from file: $GEOSERVER_ADMIN_USER_FILE"
+    fi
+elif [ -n "$GEOSERVER_ADMIN_USER_FILE" ]; then
+    echo "Error: GEOSERVER_ADMIN_USER_FILE is set to '$GEOSERVER_ADMIN_USER_FILE' but file does not exist or is not readable."
+    exit 1
+elif [ -n "$GEOSERVER_ADMIN_USER" ]; then
+    ADMIN_USER="$GEOSERVER_ADMIN_USER"
+fi
+
+# Update credentials if both username and password are available
+if [ -n "$ADMIN_PASSWORD" ] && [ -n "$ADMIN_USER" ]; then
+    echo "Updating GeoServer admin credentials..."
+    /bin/sh /opt/update_credentials.sh "$ADMIN_USER" "$ADMIN_PASSWORD"
 fi
 
 # Run as non-privileged user

--- a/update_credentials.sh
+++ b/update_credentials.sh
@@ -14,8 +14,16 @@ if [ ! -d "${GEOSERVER_DATA_DIR}/security" ]; then
   cp -r "${CATALINA_HOME}/webapps/geoserver/data/security" "${GEOSERVER_DATA_DIR}/"
 fi
 
-GEOSERVER_ADMIN_USER=${GEOSERVER_ADMIN_USER:-admin}
-GEOSERVER_ADMIN_PASSWORD=${GEOSERVER_ADMIN_PASSWORD:-geoserver}
+# Accept credentials as arguments or fallback to environment variables
+if [ $# -eq 2 ]; then
+  GEOSERVER_ADMIN_USER="$1"
+  GEOSERVER_ADMIN_PASSWORD="$2"
+  echo "Using credentials provided as script arguments"
+else
+  GEOSERVER_ADMIN_USER=${GEOSERVER_ADMIN_USER:-admin}
+  GEOSERVER_ADMIN_PASSWORD=${GEOSERVER_ADMIN_PASSWORD:-geoserver}
+  echo "Using credentials from environment variables (or defaults)"
+fi
 
 # templates to use as base for replacement
 USERS_XML_ORIG="${CATALINA_HOME}/webapps/geoserver/data/security/usergroup/default/users.xml"


### PR DESCRIPTION
This PR enables users to provide GeoServer admin credentials via container secrets, keeping GEOSERVER_ADMIN_PASSWORD out of environment variables.

Additionally, the README has been updated to reflect these changes.