### PR TITLE
fix: respect gdal builder image in builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -83,6 +83,7 @@ jobs:
       major: ${{ steps.parse.outputs.major }}
       minor: ${{ steps.parse.outputs.minor }}
       base_image: ${{ steps.parse.outputs.base_image }}
+      builder_base_image: ${{ steps.parse.outputs.builder_base_image }}
       branch: ${{ steps.parse.outputs.branch }}
       is_nightly: ${{ steps.parse.outputs.is_nightly }}
       war_url: ${{ steps.parse.outputs.war_url }}
@@ -133,14 +134,19 @@ jobs:
           # Determine base image based on version
           if [[ "$VERSION" == "3"* ]]; then
             BASE_IMAGE="tomcat:11.0-jdk21-temurin-noble"
+            BUILDER_BASE_IMAGE="eclipse-temurin:21-jdk-noble"
           elif [[ "$VERSION" == "2.28"* ]]; then
             BASE_IMAGE="tomcat:9.0-jdk21-temurin-noble"
+            BUILDER_BASE_IMAGE="eclipse-temurin:21-jdk-noble"
           elif [[ "$VERSION" == "2.27"* ]] || [[ "$VERSION" == "2.26"* ]]; then
             BASE_IMAGE="tomcat:9.0-jdk17-temurin-noble"
+            BUILDER_BASE_IMAGE="eclipse-temurin:17-jdk-noble"
           else
             BASE_IMAGE="tomcat:9.0-jdk11-temurin-noble"
+            BUILDER_BASE_IMAGE="eclipse-temurin:11-jdk-noble"
           fi
           echo "base_image=$BASE_IMAGE" >> $GITHUB_OUTPUT
+          echo "builder_base_image=$BUILDER_BASE_IMAGE" >> $GITHUB_OUTPUT
           
           # Determine branch and tag based on version pattern
           if [[ "$VERSION" == *"-M"* ]] || [[ "$VERSION" == *"-RC"* ]]; then
@@ -248,6 +254,7 @@ jobs:
           echo "  Version: $VERSION"
           echo "  Branch: $BRANCH"
           echo "  Base Image: $BASE_IMAGE"
+          echo "  (GDAL) Builder Base Image: $BUILDER_BASE_IMAGE"
           echo "  Is Nightly: $IS_NIGHTLY"
           echo "  Primary Tag: $PRIMARY_TAG"
           echo "  Additional Tags: $ADDITIONAL_TAGS"
@@ -321,11 +328,13 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          pull: true
           build-args: |
             GS_VERSION=${{ needs.prepare.outputs.version }}
             GS_BUILD=${{ needs.prepare.outputs.build_number }}
             BUILD_GDAL=${{ matrix.gdal }}
             GEOSERVER_BASE_IMAGE=${{ needs.prepare.outputs.base_image }}
+            BUILDER_BASE_IMAGE=${{ needs.prepare.outputs.builder_base_image }}
             WAR_ZIP_URL=${{ needs.prepare.outputs.war_url }}
             STABLE_PLUGIN_URL=${{ needs.prepare.outputs.stable_plugin_url }}
             COMMUNITY_PLUGIN_URL=${{ needs.prepare.outputs.community_plugin_url }}
@@ -465,6 +474,7 @@ jobs:
           - **Version**: ${{ needs.prepare.outputs.version }}
           - **Build Number**: ${{ needs.prepare.outputs.build_number }}
           - **Base Image**: ${{ needs.prepare.outputs.base_image }}
+          - **(GDAL) Builder Base Image**: ${{ needs.prepare.outputs.builder_base_image }}
           - **Is Nightly**: ${{ needs.prepare.outputs.is_nightly }}
           
           ### Images Created

--- a/build/release.sh
+++ b/build/release.sh
@@ -22,7 +22,7 @@ function build_geoserver_image() {
     local BRANCH=$5
 
     if [ -n "$VERSION" ] && [ -n "$BUILD" ] && [ -n "$BUILD_GDAL" ] && [ -n "$TAG" ]; then
-      
+
       if [[ "$VERSION" == "3"* ]]; then
         GEOSERVER_BASE_IMAGE=tomcat:11.0-jdk21-temurin-noble
         BUILDER_BASE_IMAGE=eclipse-temurin:21-jdk-noble
@@ -34,32 +34,30 @@ function build_geoserver_image() {
         BUILDER_BASE_IMAGE=eclipse-temurin:17-jdk-noble
       fi
 
+      # Only nightly/snapshot builds pull WAR and plugins from build.geoserver.org.
+      # Stable releases skip these extra args but must still receive the base
+      # image args and --pull so that builder and runtime images stay in sync
+      # and the latest base images are always used.
+      EXTRA_ARGS=()
       if [ -n "$BRANCH" ]; then
-        # all needed vars are set
-
-        (set -x # echo docker build command
-        docker build \
-            --build-arg WAR_ZIP_FILE="geoserver-$BRANCH-latest-war.zip" \
-            --build-arg WAR_ZIP_URL="https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip" \
-            --build-arg STABLE_PLUGIN_URL="https://build.geoserver.org/geoserver/$BRANCH/ext-latest" \
-            --build-arg COMMUNITY_PLUGIN_URL="https://build.geoserver.org/geoserver/$BRANCH/community-latest" \
-            --build-arg GS_VERSION="$VERSION" \
-            --build-arg GS_BUILD="$BUILD" \
-            --build-arg BUILD_GDAL="$BUILD_GDAL" \
-            --build-arg GEOSERVER_BASE_IMAGE="$GEOSERVER_BASE_IMAGE" \
-            --build-arg BUILDER_BASE_IMAGE="$BUILDER_BASE_IMAGE" \
-            --pull \
-            -t "$TAG" .)
-      elif [ -z "$BRANCH" ]; then
-        # BRANCH is not set
-
-        (set -x # echo docker build command
-        docker build \
-          --build-arg GS_VERSION=$VERSION \
-          --build-arg GS_BUILD=$BUILD \
-          --build-arg BUILD_GDAL=$BUILD_GDAL \
-          -t $TAG .)
+        EXTRA_ARGS+=(
+          --build-arg WAR_ZIP_FILE="geoserver-$BRANCH-latest-war.zip"
+          --build-arg WAR_ZIP_URL="https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip"
+          --build-arg STABLE_PLUGIN_URL="https://build.geoserver.org/geoserver/$BRANCH/ext-latest"
+          --build-arg COMMUNITY_PLUGIN_URL="https://build.geoserver.org/geoserver/$BRANCH/community-latest"
+        )
       fi
+
+      (set -x # echo docker build command
+      docker build \
+          --build-arg GS_VERSION="$VERSION" \
+          --build-arg GS_BUILD="$BUILD" \
+          --build-arg BUILD_GDAL="$BUILD_GDAL" \
+          --build-arg GEOSERVER_BASE_IMAGE="$GEOSERVER_BASE_IMAGE" \
+          --build-arg BUILDER_BASE_IMAGE="$BUILDER_BASE_IMAGE" \
+          --pull \
+          "${EXTRA_ARGS[@]}" \
+          -t "$TAG" .)
 
     else
       echo "Missing required parameters"
@@ -138,7 +136,7 @@ if [[ $1 == *build* ]]; then
     echo "  nightly build from https://build.geoserver.org/geoserver/$BRANCH"
     echo "  downloading geoserver-$BRANCH-latest-war.zip"
     wget -c -q -P./geoserver/ \
-         "https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip" 
+         "https://build.geoserver.org/geoserver/$BRANCH/geoserver-$BRANCH-latest-war.zip"
     echo
     build_geoserver_image $VERSION $BUILD "false" $TAG $BRANCH     # without gdal
     build_geoserver_image $VERSION $BUILD "true" $GDAL_TAG $BRANCH # with gdal
@@ -147,7 +145,7 @@ if [[ $1 == *build* ]]; then
     echo "  downloading geoserver-${VERSION}-war.zip"
     wget -c -q -P./geoserver/ \
          "https://downloads.sourceforge.net/project/geoserver/GeoServer/${VERSION}/geoserver-${VERSION}-war.zip"
-    echo    
+    echo
     build_geoserver_image $VERSION $BUILD "false" $TAG   # without gdal
     build_geoserver_image $VERSION $BUILD "true" $GDAL_TAG # with gdal
   fi

--- a/build/release.sh
+++ b/build/release.sh
@@ -25,10 +25,13 @@ function build_geoserver_image() {
       
       if [[ "$VERSION" == "3"* ]]; then
         GEOSERVER_BASE_IMAGE=tomcat:11.0-jdk21-temurin-noble
+        BUILDER_BASE_IMAGE=eclipse-temurin:21-jdk-noble
       elif [[ "$VERSION" == "2.28"* ]]; then	# removing trailing dot, as the check must support both 2.28.x and 2.28-SNAPSHOT
         GEOSERVER_BASE_IMAGE=tomcat:9.0-jdk21-temurin-noble
+        BUILDER_BASE_IMAGE=eclipse-temurin:21-jdk-noble
       else
         GEOSERVER_BASE_IMAGE=tomcat:9.0-jdk17-temurin-noble
+        BUILDER_BASE_IMAGE=eclipse-temurin:17-jdk-noble
       fi
 
       if [ -n "$BRANCH" ]; then
@@ -44,6 +47,8 @@ function build_geoserver_image() {
             --build-arg GS_BUILD="$BUILD" \
             --build-arg BUILD_GDAL="$BUILD_GDAL" \
             --build-arg GEOSERVER_BASE_IMAGE="$GEOSERVER_BASE_IMAGE" \
+            --build-arg BUILDER_BASE_IMAGE="$BUILDER_BASE_IMAGE" \
+            --pull \
             -t "$TAG" .)
       elif [ -z "$BRANCH" ]; then
         # BRANCH is not set

--- a/build/release.sh
+++ b/build/release.sh
@@ -29,9 +29,12 @@ function build_geoserver_image() {
       elif [[ "$VERSION" == "2.28"* ]]; then	# removing trailing dot, as the check must support both 2.28.x and 2.28-SNAPSHOT
         GEOSERVER_BASE_IMAGE=tomcat:9.0-jdk21-temurin-noble
         BUILDER_BASE_IMAGE=eclipse-temurin:21-jdk-noble
-      else
+      elif [[ "$VERSION" == "2.27"* ]] || [[ "$VERSION" == "2.26"* ]]; then
         GEOSERVER_BASE_IMAGE=tomcat:9.0-jdk17-temurin-noble
         BUILDER_BASE_IMAGE=eclipse-temurin:17-jdk-noble
+      else
+        GEOSERVER_BASE_IMAGE=tomcat:9.0-jdk11-temurin-noble
+        BUILDER_BASE_IMAGE=eclipse-temurin:11-jdk-noble
       fi
 
       # Only nightly/snapshot builds pull WAR and plugins from build.geoserver.org.


### PR DESCRIPTION
If the `BUILD_GDAL` argument is true, the GDAL java native bindings are built and integrated in the final geoserver image.

Therefore a `BUILDER_BASE_IMAGE` is used (which is another argument of the Dockerfile). Currently, the release/build process does not care about this base image, but it should always match the final gs image regarding the underlying java version.

This change adds this missing handling.

This PR also adds the `--pull` flag (in release script and github action) to always ensure that the latest available image is being pulled. Otherwise outdated images from a local cache could be used in repetitive builds.