### PR TITLE
Download latest when MAIN=3.1

### DIFF
--- a/build/download.sh
+++ b/build/download.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Update this each time a new release cycle started on https://github.com/geoserver/geoserver
-MAIN="3.0"
+MAIN="3.1"
 
 function usage() {
   echo "$0 <version> [<clean>]"


### PR DESCRIPTION
When fixing build server nightly, I noticed docker was failing with:
```
Release from branch main GeoServer 3.1-SNAPSHOT as geoserver-docker.osgeo.org/geoserver:3.1.x
Release from branch main GeoServer 3.1-SNAPSHOT (with GDAL) as geoserver-docker.osgeo.org/geoserver:3.1.x-gdal
clean: 
Downloading GeoServer for version 3.1-SNAPSHOT
  Download GeoServer 3.1-SNAPSHOT
  Download nightly build from https://build.geoserver.org/geoserver/3.1.x
  downloading geoserver-3.1.x-latest-war.zip
Build step 'Execute shell' marked build as failure
```

The correct download location should instead be `https://build.geoserver.org/geoserver/main`

This PR fixes the `download.sh` script to recognize that 3.1.x is `main`. The `download.sh` script is called by `release.sh` to avoid downloading twice (for both normal image and gdal image).