### PR TITLE
fix: correct usage of POSTGRES_JNDI_ENABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ To enable a PostgreSQL JNDI resource, provide the following environment variable
 
 In geoserver, you can then reference this JNDI resource using the name `java:comp/env/jdbc/postgres` (if using default).
 
-Note: previously you could tweak the JNDI settings in a custom `context.xml` (see below), but its contents are now included in `server.xml`.
+Note: previously the JNDI settings lived in a custom `context.xml`, but their contents are now included in `server.xml`.
 
 
 ## How to use custom (tomcat) configuration files
@@ -185,7 +185,6 @@ Note: previously you could tweak the JNDI settings in a custom `context.xml` (se
 This image provides default (tomcat) configurations that are located in the `./config/` subdir.
 
 * `server.xml` (security hardened version by default)
-* ~context.xml~ (now included into `server.xml`, previously used for JNDI settings)
 
 In case you want to fully overwrite such a config file, you can do so by mounting it to the `/opt/config_overrides/` directory of a container.
 The `startup.sh` script will then copy (and overwrite) these files to the catalina conf directory before starting tomcat.

--- a/config/server-https.xml
+++ b/config/server-https.xml
@@ -175,6 +175,7 @@
                prefix="localhost_access_log" suffix=".txt"
                pattern="%h %l %u %t &quot;%r&quot; %s %b" />
           <Context antiResourceLocking="false" override="true" docBase="geoserver" privileged="true" path="/${WEBAPP_CONTEXT}">
+               <!-- POSTGRES_JNDI_RESOURCE_BEGIN (stripped by startup.sh when POSTGRES_JNDI_ENABLED != true) -->
                <Resource name="${POSTGRES_JNDI_RESOURCE_NAME}"
                          auth="Container"
                          type="javax.sql.DataSource"
@@ -193,6 +194,7 @@
                          validationQuery="SELECT 1"
                          rollbackOnReturn="true"
                />
+               <!-- POSTGRES_JNDI_RESOURCE_END -->
           </Context>
       </Host>
     </Engine>

--- a/config/server.xml
+++ b/config/server.xml
@@ -182,6 +182,7 @@
                        pattern="%h %l %u %t &quot;%r&quot; %s %b" />
 
                 <Context antiResourceLocking="false" override="true" docBase="geoserver" privileged="true" path="/${WEBAPP_CONTEXT}">
+                    <!-- POSTGRES_JNDI_RESOURCE_BEGIN (stripped by startup.sh when POSTGRES_JNDI_ENABLED != true) -->
                     <Resource name="${POSTGRES_JNDI_RESOURCE_NAME}"
                             auth="Container"
                             type="javax.sql.DataSource"
@@ -200,6 +201,7 @@
                             validationQuery="SELECT 1"
                             rollbackOnReturn="true"
                     />
+                    <!-- POSTGRES_JNDI_RESOURCE_END -->
                 </Context>
             </Host>
         </Engine>

--- a/startup.sh
+++ b/startup.sh
@@ -99,7 +99,7 @@ total_count=$((ttf_count + ttc_count))
 if [ -d "$ADDITIONAL_FONTS_DIR" ] && [ $total_count != 0 ]; then
     [ "$ttf_count" -gt 0 ] && cp "$ADDITIONAL_FONTS_DIR"/*.ttf /usr/share/fonts/truetype/
     [ "$ttc_count" -gt 0 ] && cp "$ADDITIONAL_FONTS_DIR"/*.ttc /usr/share/fonts/truetype/
-    
+
     echo "Installed $total_count ttf/ttc font file(s) from the additional fonts folder"
 fi
 
@@ -173,11 +173,6 @@ if [ "${CORS_ENABLED}" = "true" ]; then
   fi
 fi
 
-if [ "${POSTGRES_JNDI_ENABLED}" = "true" ]; then
-  # Use a custom "context.xml" if the user mounted one into the container
-  copy_custom_config "context.xml"
-fi
-
 # Use a custom "server.xml" if the user mounted one into the container
 copy_custom_config "server.xml"
 
@@ -203,6 +198,14 @@ if [ "${HTTPS_ENABLED}" = "true" ]; then
   fi
   echo "Installing [${CATALINA_HOME}/conf/server.xml] with HTTPS support using substituted environment variables"
   envsubst < "${CONFIG_DIR}"/server-https.xml > "${CATALINA_HOME}/conf/server.xml"
+fi
+
+# Strip the PostgreSQL JNDI <Resource> block from server.xml unless JNDI is
+# explicitly enabled. The block is wrapped in
+# <!-- POSTGRES_JNDI_RESOURCE_BEGIN --> ... <!-- POSTGRES_JNDI_RESOURCE_END -->
+# markers in the default server.xml / server-https.xml templates.
+if [ "${POSTGRES_JNDI_ENABLED}" != "true" ]; then
+  sed -i '/POSTGRES_JNDI_RESOURCE_BEGIN/,/POSTGRES_JNDI_RESOURCE_END/d' "$CATALINA_HOME/conf/server.xml"
 fi
 
 # start the tomcat

--- a/startup.sh
+++ b/startup.sh
@@ -1,17 +1,31 @@
 #!/bin/bash
 echo "Welcome to GeoServer $GEOSERVER_VERSION"
 
+# Filter that strips the PostgreSQL JNDI <Resource> block from stdin unless
+# POSTGRES_JNDI_ENABLED is "true". The block is wrapped in
+# <!-- POSTGRES_JNDI_RESOURCE_BEGIN --> ... <!-- POSTGRES_JNDI_RESOURCE_END -->
+# markers in the default server.xml / server-https.xml templates. Applying the
+# filter before envsubst ensures that credentials (e.g. POSTGRES_JNDI_PASSWORD)
+# are never substituted into the rendered file when JNDI is disabled.
+function maybe_strip_jndi_resource() {
+  if [ "${POSTGRES_JNDI_ENABLED}" = "true" ]; then
+    cat
+  else
+    sed '/POSTGRES_JNDI_RESOURCE_BEGIN/,/POSTGRES_JNDI_RESOURCE_END/d'
+  fi
+}
+
 # function that can be used to copy a custom config file to the catalina conf dir
 function copy_custom_config() {
   CONFIG_FILE=$1
   # Use a custom "${CONFIG_FILE}" if the user mounted one into the container
   if [ -d "${CONFIG_OVERRIDES_DIR}" ] && [ -f "${CONFIG_OVERRIDES_DIR}/${CONFIG_FILE}" ]; then
     echo "Installing configuration override for ${CONFIG_FILE} with substituted environment variables"
-    envsubst < "${CONFIG_OVERRIDES_DIR}"/"${CONFIG_FILE}" > "${CATALINA_HOME}/conf/${CONFIG_FILE}"
+    maybe_strip_jndi_resource < "${CONFIG_OVERRIDES_DIR}"/"${CONFIG_FILE}" | envsubst > "${CATALINA_HOME}/conf/${CONFIG_FILE}"
   elif [ -f "${CONFIG_DIR}/${CONFIG_FILE}" ]; then
     # Otherwise use the default if it exists
     echo "Installing default ${CONFIG_FILE} with substituted environment variables"
-    envsubst < "${CONFIG_DIR}"/"${CONFIG_FILE}" > "${CATALINA_HOME}/conf/${CONFIG_FILE}"
+    maybe_strip_jndi_resource < "${CONFIG_DIR}"/"${CONFIG_FILE}" | envsubst > "${CATALINA_HOME}/conf/${CONFIG_FILE}"
 
     # since autodeploy is disabled by default, we need to enable it if the user has not provided a custom server.xml
     if [ "${CONFIG_FILE}" = "server.xml" ] && [ "${ROOT_WEBAPP_REDIRECT}" = "true" ] && [ "${WEBAPP_CONTEXT}" != "" ]; then
@@ -197,15 +211,7 @@ if [ "${HTTPS_ENABLED}" = "true" ]; then
     exit 1
   fi
   echo "Installing [${CATALINA_HOME}/conf/server.xml] with HTTPS support using substituted environment variables"
-  envsubst < "${CONFIG_DIR}"/server-https.xml > "${CATALINA_HOME}/conf/server.xml"
-fi
-
-# Strip the PostgreSQL JNDI <Resource> block from server.xml unless JNDI is
-# explicitly enabled. The block is wrapped in
-# <!-- POSTGRES_JNDI_RESOURCE_BEGIN --> ... <!-- POSTGRES_JNDI_RESOURCE_END -->
-# markers in the default server.xml / server-https.xml templates.
-if [ "${POSTGRES_JNDI_ENABLED}" != "true" ]; then
-  sed -i '/POSTGRES_JNDI_RESOURCE_BEGIN/,/POSTGRES_JNDI_RESOURCE_END/d' "$CATALINA_HOME/conf/server.xml"
+  maybe_strip_jndi_resource < "${CONFIG_DIR}"/server-https.xml | envsubst > "${CATALINA_HOME}/conf/server.xml"
 fi
 
 # start the tomcat


### PR DESCRIPTION
## fix: correct usage of `POSTGRES_JNDI_ENABLED`

### Background
The PostgreSQL JNDI configuration was moved some time ago from a separate `context.xml` into `server.xml` (and `server-https.xml`). As a side effect, `POSTGRES_JNDI_ENABLED` became effectively a no-op: the `<Resource>` definition was hard-coded in `server.xml`, and the only remaining code path that still evaluated the variable merely tried to copy a (no longer existing) `context.xml`.

As a result, the JNDI resource was **always** created — even when `POSTGRES_JNDI_ENABLED` was unset or `false`.

### Changes
- `config/server.xml` and `config/server-https.xml`: The `<Resource>` block for the PostgreSQL JNDI DataSource is now wrapped with marker comments:
  ```xml
  <!-- POSTGRES_JNDI_RESOURCE_BEGIN (stripped by startup.sh when POSTGRES_JNDI_ENABLED != true) -->
  ...
  <!-- POSTGRES_JNDI_RESOURCE_END -->
  ```
- `startup.sh`:
  - Removed the dead code path that attempted to copy a `context.xml`.
  - After rendering `server.xml`, the marked JNDI block is stripped via `sed` unless `POSTGRES_JNDI_ENABLED` is set to `true`.
- `README.md`: Cleaned up the note referring to the (no longer existing) `context.xml`.

### Behavior after the fix
| `POSTGRES_JNDI_ENABLED` | Result in `server.xml` |
| --- | --- |
| `true` | JNDI `<Resource>` is kept |
| unset / `false` / anything else | JNDI `<Resource>` is removed |

### How to test
1. Start a container **without** `POSTGRES_JNDI_ENABLED` → `$CATALINA_HOME/conf/server.xml` must **not** contain any `<Resource name="jdbc/postgres" .../>` entry.
2. Start a container with `POSTGRES_JNDI_ENABLED=true` and the other `POSTGRES_JNDI_*` variables set → the `<Resource>` block must be present and populated with the provided values; GeoServer can reference the DataSource via `java:comp/env/jdbc/postgres`.
3. Repeat both checks with `HTTPS_ENABLED=true` (which uses `server-https.xml` as the template).

### Breaking changes
None. Users who previously set `POSTGRES_JNDI_ENABLED=true` will get the exact same resource as before. Users who did **not** set the variable were unintentionally getting a JNDI resource anyway; this PR fixes that.